### PR TITLE
chore: add LICENSE, CONTRIBUTING, CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+By participating in this project (issues, PRs, discussions), you agree to uphold that standard.
+
+## Reporting
+
+Concerns can be reported privately to the maintainer at `bernardoagbranco@gmail.com`. Reports will be reviewed promptly and handled confidentially.
+
+## Scope
+
+Applies to all project spaces — GitHub issues, PRs, discussions — and to anyone representing the project in public.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+Thanks for taking the time to contribute. This is an early project — small, focused PRs are easier to review and more likely to land.
+
+## Dev setup
+
+```bash
+git clone https://github.com/bernabranco/claude-vault.git
+cd claude-vault
+npm install
+cd web && npm install && cd ..
+```
+
+Node 20+ required. The `better-sqlite3` native module compiles on install.
+
+## Running locally
+
+```bash
+# MCP server (stdio) — used by Claude Code via .mcp.json
+node lib/mcp.js
+
+# Web UI (browser graph viewer)
+node lib/server.js           # backend → http://localhost:4001
+cd web && npm run dev        # frontend → http://localhost:5173
+
+# CLI
+node index.js --help
+node index.js semantic-search "why SQLite over cloud DB"
+```
+
+## Before opening a PR
+
+Run the same checks CI runs:
+
+```bash
+npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js
+cd web && npx tsc --noEmit && cd ..
+npm run build
+node index.js index
+node index.js search "architecture" --limit 3
+```
+
+If those all pass locally, CI should pass too.
+
+## Workflow
+
+1. **Branch off `main`**: `git checkout -b feat/your-thing`
+2. **Commit style**: conventional-ish prefixes (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`). Short imperative subject, body optional.
+3. **Open a PR** against `main`. CI will run — wait for green before asking for review.
+4. **Merge** via `gh pr merge --merge` (preserves history — this project doesn't squash).
+
+## Reporting bugs
+
+Open a GitHub issue with:
+- What you were trying to do
+- What happened vs. what you expected
+- Node version, OS, and anything in `.vault-cache/embeddings.db` state that might matter
+- Minimal repro if possible
+
+## Scope notes
+
+- **Keep the MCP server surface small.** Eight tools today — adding a ninth is a deliberate choice, not a default. New tools should have a clear reason they can't be composed from existing ones.
+- **Local-first stays.** No cloud calls on the critical path. Embeddings run locally, data stays on disk.
+- **Markdown is the source of truth.** The database is a cache. If the cache disagrees with the files, the files win.
+
+## Questions
+
+Open a GitHub discussion or issue. Early-stage project — I'd rather talk than guess what you need.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 bernabranco
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- LICENSE (MIT) — matches what README already claims
- CONTRIBUTING.md — dev setup, local checks mirroring CI, branch/commit/merge workflow
- CODE_OF_CONDUCT.md — Contributor Covenant 2.1, with reporting email

## Test plan
- [ ] CI green on both Node 20.x and 22.x
- [ ] LICENSE detected by GitHub (shown on repo page sidebar)
- [ ] CONTRIBUTING.md linked from the "Contribute" prompt when opening issues/PRs
- [ ] CODE_OF_CONDUCT.md detected by GitHub (Community Standards checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)