### PR TITLE
chore: prep package for npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # claude-vault
 
-**A markdown knowledge vault designed for Claude — not adapted to Claude.**
+**A markdown knowledge vault designed for Claude.**
 
 [![CI](https://github.com/bernabranco/claude-vault/actions/workflows/ci.yml/badge.svg)](https://github.com/bernabranco/claude-vault/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,21 @@
 {
   "name": "claude-vault",
   "version": "0.1.0",
-  "description": "Local-first markdown knowledge vault for Claude Code — index, search, and export context",
+  "description": "Local-first markdown knowledge vault for Claude Code — semantic search, graph-aware context, and MCP integration",
   "main": "index.js",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bernabranco/claude-vault.git"
+  },
+  "homepage": "https://github.com/bernabranco/claude-vault#readme",
+  "bugs": {
+    "url": "https://github.com/bernabranco/claude-vault/issues"
+  },
+  "files": [
+    "index.js",
+    "lib/"
+  ],
   "scripts": {
     "dev": "concurrently \"node --watch lib/server.js\" \"cd web && npm run dev\"",
     "build": "cd web && npm run build",
@@ -36,10 +48,19 @@
   },
   "keywords": [
     "claude",
+    "claude-code",
+    "mcp",
+    "model-context-protocol",
     "knowledge-management",
+    "knowledge-base",
+    "knowledge-graph",
     "markdown",
     "vault",
-    "obsidian"
+    "rag",
+    "embeddings",
+    "semantic-search",
+    "local-first",
+    "sqlite"
   ],
   "author": "bernabranco",
   "license": "MIT",


### PR DESCRIPTION
Closes #2 once merged + \`npm publish\` runs.

## Summary

- Add \`repository\`, \`homepage\`, \`bugs\` to package.json (npm page links back to GitHub)
- Add \`files\` whitelist — ship only \`index.js\` + \`lib/\`; exclude \`vault/\` demo notes, \`web/\` UI source, CI config, tsconfig
- Expand \`keywords\` to match repo topics (\`claude-code\`, \`mcp\`, \`rag\`, \`embeddings\`, \`semantic-search\`, \`local-first\`, \`sqlite\`, etc.) for npm search discoverability
- Sharpen \`description\` — mentions actual features (semantic search, graph context, MCP) instead of generic phrasing
- Trim README hero tagline to \"designed for Claude.\"

## Tarball contents after \`files\` whitelist

\`\`\`
10 files, 19 kB packed / 67 kB unpacked:
  LICENSE, README.md, package.json   (auto)
  index.js                            (CLI entry)
  lib/chunks.js
  lib/embeddings.js
  lib/graph.js
  lib/mcp.js
  lib/server.js
  lib/vault.js
\`\`\`

## Test plan

Verified locally before opening this PR:

- [x] \`npm view claude-vault\` → 404 (name available)
- [x] \`npm pack --dry-run\` → confirms only 10 files above
- [x] \`npm pack\` + \`npm install <tarball>\` in throwaway dir → resolves, no errors on Node 22
- [x] \`./node_modules/.bin/claude-vault init test-app\` → creates \`vault/test-app/\` with drawers + \`.mcp.json\` + \`.gitignore\` correctly
- [x] MCP server starts from installed package and \`tools/list\` returns all 8 vault tools

## Next step (after merge)

\`\`\`bash
npm login
npm publish --access public
\`\`\`

Then close #2 and update README install instructions to use \`npx claude-vault init\`.

## Known trade-off

\`web/\` UI source is excluded from the tarball. v0.1.0 is a CLI-first release — users who want the browser graph viewer can clone the repo. Revisit if demand surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)