### PR TITLE
chore: rename npm package to claude-code-vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <div align="center">
 
-# claude-vault
+# claude-code-vault
 
 **A markdown knowledge vault designed for Claude.**
 
+[![npm version](https://img.shields.io/npm/v/claude-code-vault.svg)](https://www.npmjs.com/package/claude-code-vault)
 [![CI](https://github.com/bernabranco/claude-vault/actions/workflows/ci.yml/badge.svg)](https://github.com/bernabranco/claude-vault/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](package.json)
@@ -19,7 +20,7 @@
 
 ---
 
-Most PKM tools (Obsidian, Logseq, Notion) were built for humans writing notes; LLM features are bolted on as plugins. `claude-vault` starts from the other direction: **what would a knowledge base look like if an LLM agent was the primary consumer?**
+Most PKM tools (Obsidian, Logseq, Notion) were built for humans writing notes; LLM features are bolted on as plugins. `claude-code-vault` starts from the other direction: **what would a knowledge base look like if an LLM agent was the primary consumer?**
 
 Browse the demo vault shipped with this repo at [`vault/tempo/`](vault/tempo/) — a fake focus-timer SaaS with ADRs, features, gotchas, market research, and pricing, all wiki-linked into a real graph.
 
@@ -54,7 +55,7 @@ vault/
 │   ├── technical/              ← code, architecture, features, gotchas, ADRs
 │   ├── strategy/               ← research, roadmap, product direction
 │   └── business/               ← GTM, pricing, rollout
-└── your-project/               ← (added by `claude-vault init`)
+└── your-project/               ← (added by `claude-code-vault init`)
     └── ...
 ```
 
@@ -77,13 +78,13 @@ cd web && npm run dev              # http://localhost:5173 (dev mode)
 ## Bootstrap a vault in any repo
 
 ```bash
-claude-vault init [project-name]
+npx claude-code-vault init [project-name]
 ```
 
 Defaults the project name to the current directory name. Creates:
 
 - `vault/<project>/` with drawer structure (`technical/`, `strategy/`, `business/`) and stub `VAULT_SUMMARY.md` + `overview.md`
-- `.mcp.json` at repo root wiring Claude Code to the vault's MCP server (uses `npx claude-vault mcp` with `VAULT_DIR=./vault`)
+- `.mcp.json` at repo root wiring Claude Code to the vault's MCP server (uses `npx claude-code-vault mcp` with `VAULT_DIR=./vault`)
 - `.vault-cache/` entry in `.gitignore` so the local embeddings DB isn't committed
 
 Idempotent: re-running skips existing files. After it finishes, restart Claude Code in the directory to load the vault tools.
@@ -133,8 +134,8 @@ node index.js search-with-context "tab throttling" --limit 3 --depth 2
 - [x] **Semantic search** — local embeddings via `@huggingface/transformers` + `sqlite-vec`
 - [x] **Chunk-level retrieval** — return the most relevant paragraphs with heading breadcrumbs, not whole files
 - [x] **Graph-aware context** — `vault_read_with_context` and `vault_search_chunks_with_context` return ranked neighbors with snippets
-- [x] **`claude-vault init`** — one command bootstraps a vault, `.mcp.json`, and `.gitignore` in any repo
-- [ ] **[npm publish](https://github.com/bernabranco/claude-vault/issues/2)** — install via `npx claude-vault init` without cloning
+- [x] **`claude-code-vault init`** — one command bootstraps a vault, `.mcp.json`, and `.gitignore` in any repo
+- [x] **[npm published](https://www.npmjs.com/package/claude-code-vault)** — install via `npx claude-code-vault init`
 - [ ] **[Hybrid search](https://github.com/bernabranco/claude-vault/issues/4)** — fuse keyword + semantic scores via RRF
 - [ ] **[Reranker](https://github.com/bernabranco/claude-vault/issues/5)** — cross-encoder pass over top-K for precision
 - [ ] **[Public launch polish](https://github.com/bernabranco/claude-vault/issues/3)** — demo GIF, examples, comparison screenshots

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const program = new Command();
 
 program
-  .name("claude-vault")
+  .name("claude-code-vault")
   .description("Markdown knowledge vault for Claude")
   .version(pkg.version)
   .option("--vault <dir>", "Vault directory", "./vault");
@@ -68,7 +68,7 @@ Navigation guide for this project's knowledge base.
 1. Read \`overview.md\` for a quick intro
 2. Add notes to the appropriate drawer
 3. Use \`[[wikilinks]]\` to connect related notes
-4. Run \`claude-vault check\` to validate
+4. Run \`claude-code-vault check\` to validate
 
 ## 🔗 See Also
 
@@ -122,9 +122,9 @@ Start here. Briefly describe the project.
       const relVault = path.relative(process.cwd(), path.resolve(vaultDir)) || ".";
       const mcpConfig = {
         mcpServers: {
-          "claude-vault": {
+          "claude-code-vault": {
             command: "npx",
-            args: ["claude-vault", "mcp"],
+            args: ["claude-code-vault", "mcp"],
             env: { VAULT_DIR: `./${relVault}` },
           },
         },

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -53,7 +53,7 @@ const watcher = chokidar
   .watch(vaultDir, { ignoreInitial: true, ignored: /(^|[\/\\])\../ })
   .on("all", scheduleReindex);
 
-const server = new McpServer({ name: "claude-vault", version: "0.1.0" });
+const server = new McpServer({ name: "claude-code-vault", version: "0.1.0" });
 
 const safe = (handler) => async (args) => {
   try {

--- a/lib/server.js
+++ b/lib/server.js
@@ -120,7 +120,7 @@ app.get("*", (req, res) => {
 
 app.listen(PORT, () => {
   console.log("\n╔════════════════════════════════════════╗");
-  console.log("║      claude-vault running              ║");
+  console.log("║      claude-code-vault running         ║");
   console.log(`║  http://localhost:${PORT}`.padEnd(40) + "║");
   console.log("║  Vault: ./vault                        ║");
   console.log(`║  Notes: ${vault.index.length}`.padEnd(40) + "║");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "claude-vault",
+  "name": "claude-code-vault",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-vault",
+      "name": "claude-code-vault",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -19,8 +19,7 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "claude-vault": "index.js",
-        "vault": "index.js"
+        "claude-code-vault": "index.js"
       },
       "devDependencies": {
         "concurrently": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-vault",
+  "name": "claude-code-vault",
   "version": "0.1.0",
   "description": "Local-first markdown knowledge vault for Claude Code — semantic search, graph-aware context, and MCP integration",
   "main": "index.js",
@@ -29,8 +29,7 @@
     "vault:list": "node index.js list"
   },
   "bin": {
-    "claude-vault": "index.js",
-    "vault": "index.js"
+    "claude-code-vault": "index.js"
   },
   "dependencies": {
     "@huggingface/transformers": "^4.1.0",


### PR DESCRIPTION
Closes #2 — package is **live on npm: [claude-code-vault](https://www.npmjs.com/package/claude-code-vault)**.

## Why the rename?

\`npm publish\` rejected \`claude-vault\` with a 403 — npm's similarity check flagged it as too close to an existing package (\`claudevault\`). Scoping under \`@bernabranco/\` would have worked, but an unscoped distinct name is simpler for discovery and typing.

## What changed

- **package.json**: \`name\` → \`claude-code-vault\`; \`bin\` → single \`claude-code-vault\` entry (dropped \`vault\` alias to avoid colliding with HashiCorp Vault CLI on global installs)
- **index.js**: commander \`.name()\` + the \`.mcp.json\` template that \`init\` writes (\`npx claude-code-vault mcp\`)
- **lib/mcp.js, lib/server.js**: MCP server identifier + console banner
- **README**: title, hero body reference, install command (\`npx claude-code-vault init\`), roadmap checkbox flipped to \`[x] npm published\`, added npm version badge

## What stayed the same

- GitHub repository name (\`bernabranco/claude-vault\`) — all existing issue/PR/URL links remain valid
- CI workflows, CONTRIBUTING.md, CoC, LICENSE
- \`web/\` UI workspace

## Test plan

Verified via \`npm pack --dry-run\` before publish:
- [x] Tarball filename: \`claude-code-vault-0.1.0.tgz\`
- [x] 10 files, 67 kB unpacked (identical contents to the previous pack)
- [x] \`npm view claude-code-vault\` returns \`0.1.0\` with correct metadata
- [x] Install + \`npx claude-code-vault init test-app\` end-to-end works

After merge, CI should also pass green on both Node 20.x + 22.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)