### PR TITLE
chore: rename repo references to claude-code-vault + bump 0.1.1

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "claude-vault": {
+    "claude-code-vault": {
       "command": "node",
       "args": ["lib/mcp.js"]
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Thanks for taking the time to contribute. This is an early project — small, fo
 ## Dev setup
 
 ```bash
-git clone https://github.com/bernabranco/claude-vault.git
-cd claude-vault
+git clone https://github.com/bernabranco/claude-code-vault.git
+cd claude-code-vault
 npm install
 cd web && npm install && cd ..
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **A markdown knowledge vault designed for Claude.**
 
 [![npm version](https://img.shields.io/npm/v/claude-code-vault.svg)](https://www.npmjs.com/package/claude-code-vault)
-[![CI](https://github.com/bernabranco/claude-vault/actions/workflows/ci.yml/badge.svg)](https://github.com/bernabranco/claude-vault/actions/workflows/ci.yml)
+[![CI](https://github.com/bernabranco/claude-code-vault/actions/workflows/ci.yml/badge.svg)](https://github.com/bernabranco/claude-code-vault/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](package.json)
 [![MCP](https://img.shields.io/badge/MCP-compatible-8A2BE2)](https://modelcontextprotocol.io)
@@ -150,9 +150,9 @@ node index.js search-with-context "tab throttling" --limit 3 --depth 2
 - [x] **Graph-aware context** — `vault_read_with_context` and `vault_search_chunks_with_context` return ranked neighbors with snippets
 - [x] **`claude-code-vault init`** — one command bootstraps a vault, `.mcp.json`, and `.gitignore` in any repo
 - [x] **[npm published](https://www.npmjs.com/package/claude-code-vault)** — install via `npx claude-code-vault init`
-- [ ] **[Hybrid search](https://github.com/bernabranco/claude-vault/issues/4)** — fuse keyword + semantic scores via RRF
-- [ ] **[Reranker](https://github.com/bernabranco/claude-vault/issues/5)** — cross-encoder pass over top-K for precision
-- [ ] **[Public launch polish](https://github.com/bernabranco/claude-vault/issues/3)** — demo GIF, examples, comparison screenshots
+- [ ] **[Hybrid search](https://github.com/bernabranco/claude-code-vault/issues/4)** — fuse keyword + semantic scores via RRF
+- [ ] **[Reranker](https://github.com/bernabranco/claude-code-vault/issues/5)** — cross-encoder pass over top-K for precision
+- [ ] **[Public launch polish](https://github.com/bernabranco/claude-code-vault/issues/3)** — demo GIF, examples, comparison screenshots
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "claude-code-vault",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local-first markdown knowledge vault for Claude Code — semantic search, graph-aware context, and MCP integration",
   "main": "index.js",
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bernabranco/claude-vault.git"
+    "url": "git+https://github.com/bernabranco/claude-code-vault.git"
   },
-  "homepage": "https://github.com/bernabranco/claude-vault#readme",
+  "homepage": "https://github.com/bernabranco/claude-code-vault#readme",
   "bugs": {
-    "url": "https://github.com/bernabranco/claude-vault/issues"
+    "url": "https://github.com/bernabranco/claude-code-vault/issues"
   },
   "files": [
     "index.js",

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>claude-vault — Knowledge Vault</title>
+    <title>claude-code-vault — Knowledge Vault</title>
   </head>
   <body class="bg-white dark:bg-slate-950">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Repo renamed on GitHub from `claude-vault` to `claude-code-vault` to match the npm package name
- Update all internal references: package.json URLs, README badges/issue links, CONTRIBUTING clone URL, `.mcp.json` server key, browser title
- Bump version to 0.1.1 for a republish with updated README (screenshots + agnostic note)

## Test plan
- [x] `npm view claude-code-vault` shows new repository URL after publish
- [x] README badges resolve against new repo
- [x] `npx claude-code-vault init` templates the new MCP key