### PR TITLE
fix: web viewer honors VAULT_DIR (point at caller's repo vault)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ The vault is just markdown — Claude reads files directly, no backend required 
 npm install
 cd web && npm install && cd ..
 
-# Run backend + UI (optional, for browsing)
-node lib/server.js                # http://localhost:4001
-cd web && npm run dev              # http://localhost:5173 (dev mode)
+# Run backend + UI — indexes ./vault in the current directory by default
+node lib/server.js                               # http://localhost:4001
+VAULT_DIR=./path/to/your/vault node lib/server.js   # point at any folder
+cd web && npm run dev                            # http://localhost:5173 (dev mode)
 ```
+
+Run from the root of your repo (the one where `claude-code-vault init` created `vault/<your-project>/`) and the viewer picks it up automatically. Use `VAULT_DIR` to point at a vault elsewhere.
 
 <p align="center">
   <img src="assets/print1.jpg" alt="Note reader view showing the vault conventions document, with folder tree on the left and rendered markdown in the middle" width="100%" />

--- a/index.js
+++ b/index.js
@@ -480,6 +480,7 @@ program
   .description("Start the web server")
   .action(async (options) => {
     process.env.PORT = options.port;
+    process.env.VAULT_DIR = program.opts().vault;
     await import("./lib/server.js");
   });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,12 @@ import chokidar from "chokidar";
 import { Vault } from "./vault.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const vault = new Vault("./vault");
+
+// Loaded Vault: override via VAULT_DIR env var, or hardcode the fallback below
+// to point at your repo's vault (e.g. "/Users/your-work-repo/vault").
+const vaultDir = process.env.VAULT_DIR || "./vault";
+
+const vault = new Vault(vaultDir);
 const app = express();
 const PORT = process.env.PORT || 4001;
 
@@ -19,7 +24,7 @@ console.log(`✓ Indexed ${vault.index.length} notes`);
 
 // Watch for changes to vault files
 chokidar
-  .watch("./vault/**/*.md", { ignoreInitial: true })
+  .watch(path.join(vaultDir, "**/*.md"), { ignoreInitial: true })
   .on("all", async (event, filePath) => {
     console.log(`[${event}] ${filePath} — re-indexing...`);
     await vault.reindex();
@@ -122,7 +127,7 @@ app.listen(PORT, () => {
   console.log("\n╔════════════════════════════════════════╗");
   console.log("║      claude-code-vault running         ║");
   console.log(`║  http://localhost:${PORT}`.padEnd(40) + "║");
-  console.log("║  Vault: ./vault                        ║");
+  console.log(`║  Vault: ${vaultDir}`.padEnd(40) + "║");
   console.log(`║  Notes: ${vault.index.length}`.padEnd(40) + "║");
   console.log("╚════════════════════════════════════════╝\n");
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-vault",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Local-first markdown knowledge vault for Claude Code — semantic search, graph-aware context, and MCP integration",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- `lib/server.js` now reads `VAULT_DIR` (fallback `./vault`) instead of hardcoding `./vault`. Both the `Vault` init and the chokidar watcher use it, and the startup banner prints the resolved path.
- `index.js` `serve` command forwards `--vault` through `VAULT_DIR` (same wiring `mcp` already had).
- README: clarify the viewer indexes `./vault` from cwd, with a `VAULT_DIR=...` override example.
- Inline comment in `lib/server.js` so users who want to hardcode the path know where.
- Bump to 0.1.2.

## Test plan
- [x] Default: `node lib/server.js` from repo root indexes `./vault` (10 notes)
- [x] Override: `VAULT_DIR=./vault/tempo node lib/server.js` scopes to tempo only (9 notes)
- [x] `claude-code-vault serve --vault ./elsewhere` passes through