### PR TITLE
feat(claude): add /merge slash command

### DIFF
--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,0 +1,30 @@
+---
+description: Code review + merge an existing PR on claude-code-vault
+argument-hint: "<pr-number>"
+---
+
+Review and merge PR #$ARGUMENTS on `bernabranco/claude-code-vault`.
+
+Steps:
+
+1. **Preflight** — Run `git status --short`. If the working tree is dirty, stop and ask the user to stash or commit before continuing. Never stash automatically.
+
+2. **Inspect** — `gh pr view $ARGUMENTS --repo bernabranco/claude-code-vault --json state,mergeable,statusCheckRollup,headRefName,title`.
+   - `state` must be `OPEN`.
+   - `mergeable` must be `MERGEABLE` (not `CONFLICTING` or `UNKNOWN`).
+   - Every check in `statusCheckRollup` must be `SUCCESS`.
+   - Stop and report on any failure.
+
+3. **Checkout** — `gh pr checkout $ARGUMENTS --repo bernabranco/claude-code-vault`. Confirm HEAD matches the PR's `headRefName`.
+
+4. **Changed files** — `gh pr diff $ARGUMENTS --repo bernabranco/claude-code-vault --name-only`. Show the list.
+
+5. **Code review** — Invoke the `code-reviewer` agent: "Review PR #$ARGUMENTS on claude-code-vault. Files: [list]. Be strict — this is a published npm package. Flag critical/high as blockers, medium as warnings. Apply the surface-specific checklist for each file."
+
+6. **Gate** — If any critical or high findings, stop. Post the findings as a PR comment via `gh pr comment $ARGUMENTS --repo bernabranco/claude-code-vault --body "..."` and ask the user how to proceed. Do not merge.
+
+7. **Merge** — Hand off to the `release-manager` agent: "Merge PR #$ARGUMENTS on `bernabranco/claude-code-vault` using `gh pr merge $ARGUMENTS --repo bernabranco/claude-code-vault --merge --delete-branch`. Respect the hard rules — never `--squash`, never force-push, never `--no-verify`. If branch protection blocks, surface the error and ask before using `--admin`."
+
+8. **Restore** — `git checkout main && git pull --ff-only origin main`.
+
+Report: PR title, merged commit SHA, link, and any review findings that were below the blocker threshold (so the user knows what was not blocking but worth seeing).


### PR DESCRIPTION
## Summary
- Ports the `/merge` slash command from claude-atlas so the vault repo has the same review-and-merge flow as its sibling project.
- Closes the only real structural gap between the two `.claude/` trees: both now share `daily`, `fix`, `merge`, `publish`, `review`, `ship` (6 commands, 4 agents).

## Context
I compared `.claude/` between `claude-atlas` and `claude-code-vault`. The four agents (`code-reviewer`, `core-owner`, `issue-manager`, `release-manager`) and the other five commands already share structure — headings, hard-rule format, issue/PR templates, Phase A/B release flow. Their bodies diverge appropriately because the two projects have different surfaces (MCP/indexer/viewer here vs scanner/linter/viewer there).

The only missing piece was `/merge`, which shipped in claude-atlas recently. This adds it here, adapted for vault conventions.

## Adaptations vs the atlas version
- Repo references: `bernabranco/claude-code-vault` (not `claude-atlas`).
- Merge hand-off hard rule cites **never `--squash`** explicitly (matches vault's `release-manager` hard rules), where atlas uses the softer "prefer --merge" wording.
- No changes to step structure — same 8 steps, same gates.

## Changes
- `.claude/commands/merge.md`: new file, 30 lines.

## Test plan
- [ ] `/merge <pr>` picks up this PR itself (once another PR is open) and runs the full flow.
- [ ] Preflight refuses when the working tree is dirty.
- [ ] Gate blocks merge on critical/high findings from `code-reviewer`.