### PR TITLE
refactor(vault): flatten tempo drawers to type-first folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Walk-through using the demo vault. Imagine you've just opened Claude Code in a T
 Claude calls `vault_read("tempo/overview")`. Gets the overview + 4 wiki-links pointing at architecture, the core feature, pricing, and market research. Claude now knows where to look next — no grepping required.
 
 ### "Why did we pick SQLite over a cloud DB?"
-Nothing in the vault contains the literal string *"cloud DB"*. Keyword search returns zero results. Claude falls back to `vault_semantic_search("why SQLite over cloud DB")` → top hit is [`adr-001-local-first-sqlite`](vault/tempo/technical/decisions/adr-001-local-first-sqlite.md) with similarity 0.84, best-chunk heading `ADR-001 > Context`. **Meaning-based retrieval**, not substring matching.
+Nothing in the vault contains the literal string *"cloud DB"*. Keyword search returns zero results. Claude falls back to `vault_semantic_search("why SQLite over cloud DB")` → top hit is [`adr-001-local-first-sqlite`](vault/tempo/adrs/adr-001-local-first-sqlite.md) with similarity 0.84, best-chunk heading `ADR-001 > Context`. **Meaning-based retrieval**, not substring matching.
 
 ### "Where's the tab-throttling gotcha?"
-Claude doesn't want the whole [`gotchas.md`](vault/tempo/technical/architecture/gotchas.md) file — just the relevant paragraph. `vault_search_chunks("tab throttling")` returns the exact passage ("`setTimeout` in a background tab is throttled to 1s minimum") with breadcrumb `Gotchas > 1. setTimeout...`. ~40 tokens returned instead of the full file.
+Claude doesn't want the whole [`gotchas.md`](vault/tempo/gotchas/gotchas.md) file — just the relevant paragraph. `vault_search_chunks("tab throttling")` returns the exact passage ("`setTimeout` in a background tab is throttled to 1s minimum") with breadcrumb `Gotchas > 1. setTimeout...`. ~40 tokens returned instead of the full file.
 
 ### "Show me ADR-001 with its neighbors"
-`vault_read_with_context("tempo/technical/decisions/adr-001-local-first-sqlite")` returns the ADR **plus** 3 ranked graph neighbors — [`frontend-architecture`](vault/tempo/technical/architecture/frontend-architecture.md), [`focus-sessions`](vault/tempo/technical/features/focus-sessions.md), [`adr-002`](vault/tempo/technical/decisions/adr-002-web-workers-for-timers.md) — each with an intro snippet. One round-trip. Bidirectional edges first, then ranked by how many chunks reference them.
+`vault_read_with_context("tempo/adrs/adr-001-local-first-sqlite")` returns the ADR **plus** 3 ranked graph neighbors — [`frontend-architecture`](vault/tempo/designs/frontend-architecture.md), [`focus-sessions`](vault/tempo/features/focus-sessions.md), [`adr-002`](vault/tempo/adrs/adr-002-web-workers-for-timers.md) — each with an intro snippet. One round-trip. Bidirectional edges first, then ranked by how many chunks reference them.
 
 Full tool list is below. `vault_list`, `vault_related`, `vault_search`, and `vault_search_chunks_with_context` round out the other four.
 
@@ -60,14 +60,17 @@ vault/
 ├── tempo/                      ← demo vault shipped with this repo
 │   ├── VAULT_SUMMARY.md        ← index Claude reads first
 │   ├── overview.md
-│   ├── technical/              ← code, architecture, features, gotchas, ADRs
-│   ├── strategy/               ← research, roadmap, product direction
-│   └── business/               ← GTM, pricing, rollout
+│   ├── adrs/                   ← Architecture Decision Records
+│   ├── designs/                ← system/architecture designs
+│   ├── features/               ← user-facing feature specs
+│   ├── gotchas/                ← non-obvious traps, read before shipping
+│   ├── research/               ← market, user, prior-art research
+│   └── go-to-market/           ← pricing, positioning, rollout
 └── your-project/               ← (added by `claude-code-vault init`)
     └── ...
 ```
 
-One folder per project. Each project has a `VAULT_SUMMARY.md` that Claude reads as the index. Three drawers — **technical**, **strategy**, **business** — for the three kinds of content Claude is useful for.
+One folder per project. Each project has a `VAULT_SUMMARY.md` that Claude reads as the index. Inside each project, notes are grouped **by type** — `adrs/`, `designs/`, `features/`, `gotchas/`, `research/`, `go-to-market/` — so an LLM looking for *"why did we decide X"* knows to check `adrs/` without guessing. Add or skip folders as your project needs; see [`vault/README.md`](vault/README.md) for the full convention.
 
 ## Running locally
 
@@ -100,7 +103,7 @@ npx claude-code-vault init [project-name]
 
 Defaults the project name to the current directory name. Creates:
 
-- `vault/<project>/` with drawer structure (`technical/`, `strategy/`, `business/`) and stub `VAULT_SUMMARY.md` + `overview.md`
+- `vault/<project>/` with type-first folder structure (`adrs/`, `designs/`, `features/`, `gotchas/`, `research/`, `go-to-market/`) and stub `VAULT_SUMMARY.md` + `overview.md`
 - `.mcp.json` at repo root wiring Claude Code to the vault's MCP server (uses `npx claude-code-vault mcp` with `VAULT_DIR=./vault`)
 - `.vault-cache/` entry in `.gitignore` so the local embeddings DB isn't committed
 
@@ -141,7 +144,7 @@ Wiki-links form a graph. Fetching a note usually means also wanting its neighbor
 Neighbors are ranked: **bidirectional** (A ↔ B) first, then by **link frequency** (how many chunks actually reference the edge, using the per-chunk `links` array captured during chunking), then by **recency** (`lastModified`), then alphabetically. Each neighbor comes with its intro snippet (the `chunk_idx=0` chunk). A `maxChars` budget caps total snippet bytes — if we run out of room, lower-ranked neighbors are dropped and `truncated: true` is set.
 
 ```bash
-node index.js read-with-context tempo/technical/decisions/adr-001-local-first-sqlite
+node index.js read-with-context tempo/adrs/adr-001-local-first-sqlite
 node index.js search-with-context "tab throttling" --limit 3 --depth 2
 ```
 

--- a/index.js
+++ b/index.js
@@ -37,9 +37,9 @@ program
       // Doesn't exist, proceed
     }
 
-    // Create drawer structure
-    for (const drawer of ["technical", "strategy", "business"]) {
-      await fs.mkdir(path.join(projectPath, drawer), { recursive: true });
+    // Create type-first folder structure
+    for (const folder of ["adrs", "designs", "features", "gotchas", "research", "go-to-market"]) {
+      await fs.mkdir(path.join(projectPath, folder), { recursive: true });
     }
 
     // Create VAULT_SUMMARY.md
@@ -59,14 +59,17 @@ Navigation guide for this project's knowledge base.
 
 ## 📚 Structure
 
-- **\`technical/\`** — code, architecture, features, decisions, gotchas
-- **\`strategy/\`** — research, roadmap, product direction
-- **\`business/\`** — GTM, pricing, rollout
+- **\`adrs/\`** — Architecture Decision Records
+- **\`designs/\`** — system/architecture designs
+- **\`features/\`** — user-facing feature specs
+- **\`gotchas/\`** — non-obvious traps, read before shipping
+- **\`research/\`** — market, user, prior-art research
+- **\`go-to-market/\`** — pricing, positioning, rollout
 
 ## 🚀 Getting Started
 
 1. Read \`overview.md\` for a quick intro
-2. Add notes to the appropriate drawer
+2. Add notes to the folder matching their type
 3. Use \`[[wikilinks]]\` to connect related notes
 4. Run \`claude-code-vault check\` to validate
 
@@ -101,18 +104,18 @@ Start here. Briefly describe the project.
 
 ## Next steps
 
-1. Add architecture docs to \`technical/architecture/\`
-2. Add research to \`strategy/research/\`
-3. Add business info to \`business/\`
+1. Add design docs to \`designs/\`, decisions to \`adrs/\`
+2. Add research to \`research/\`
+3. Add pricing/positioning/rollout info to \`go-to-market/\`
 `
     );
 
     console.log(`✓ Created vault at ${projectPath}`);
     console.log(`  - ${path.join(project, "VAULT_SUMMARY.md")}`);
     console.log(`  - ${path.join(project, "overview.md")}`);
-    console.log(`  - ${path.join(project, "technical/")}`);
-    console.log(`  - ${path.join(project, "strategy/")}`);
-    console.log(`  - ${path.join(project, "business/")}`);
+    for (const folder of ["adrs", "designs", "features", "gotchas", "research", "go-to-market"]) {
+      console.log(`  - ${path.join(project, folder + "/")}`);
+    }
 
     const mcpPath = path.resolve(".mcp.json");
     try {

--- a/vault/README.md
+++ b/vault/README.md
@@ -2,45 +2,63 @@
 
 Local-first markdown vault for giving Claude persistent context across sessions.
 
-## One Folder Per Project
+## One folder per project, type-first inside
 
-Each project you work on gets its own top-level folder. Everything about that project — architecture, decisions, research, features, gotchas — lives inside it.
+Each project you work on gets its own top-level folder. Inside that folder, notes are grouped by **type** (adr, design, feature, gotcha, research, go-to-market) — not by audience. An LLM looking for *"why did we pick X"* knows to check `adrs/`; looking for *"what can a free user do"* knows to check `go-to-market/`. Stable folder names mean stable retrieval.
 
 ```
 vault/
 ├── README.md
-├── tempo/                    ← each project is self-contained (this one is the demo)
-│   ├── VAULT_SUMMARY.md      ← index for this project (Claude reads first)
-│   ├── overview.md
-│   ├── technical/
-│   │   ├── architecture/
-│   │   │   ├── frontend-architecture.md
-│   │   │   └── gotchas.md
-│   │   ├── decisions/        ← ADRs
-│   │   └── features/
-│   ├── strategy/
-│   │   └── research/
-│   └── business/
+├── tempo/                            ← each project is self-contained (this one is the demo)
+│   ├── VAULT_SUMMARY.md              ← index for this project (Claude reads first)
+│   ├── overview.md                   ← the elevator pitch
+│   ├── adrs/                         ← Architecture Decision Records
+│   │   ├── adr-001-local-first-sqlite.md
+│   │   └── adr-002-web-workers-for-timers.md
+│   ├── designs/                      ← system/architecture designs
+│   │   └── frontend-architecture.md
+│   ├── features/                     ← user-facing feature specs
+│   │   └── focus-sessions.md
+│   ├── gotchas/                      ← non-obvious traps, read before shipping
+│   │   └── gotchas.md
+│   ├── research/                     ← market, user, prior-art research
+│   │   └── productivity-market-2026.md
+│   └── go-to-market/                 ← pricing, positioning, rollout
+│       └── pricing.md
 ├── another-project/
 │   └── ...
-└── shared/                   ← (optional) cross-project notes
+└── shared/                           ← (optional) cross-project notes
 ```
 
-Do not put loose topic folders at the root (`architecture/`, `decisions/`, etc.) — they lose their project context. Always nest under a project.
+Do not put loose topic folders at the root (`adrs/`, `designs/`, etc.) — they lose their project context. Always nest under a project.
+
+## Folder types
+
+| Folder | What goes here |
+|---|---|
+| `adrs/` | Architecture Decision Records — why a choice was made, what was rejected, consequences |
+| `designs/` | System and component design docs — how something is built |
+| `features/` | User-facing feature specs — what the product does, flows, edge cases |
+| `gotchas/` | Non-obvious traps that bit you in production; hazards worth reading before touching the code |
+| `research/` | Market snapshots, user research, competitive analysis, prior art |
+| `go-to-market/` | Pricing, positioning, rollout, sales |
+| `runbooks/` | (optional) step-by-step operational procedures — incidents, deploys, backups |
+
+Add folders as needed; skip the ones you don't use.
 
 ## Conventions
 
 - **Every project has a `VAULT_SUMMARY.md`** at its root — this is the index Claude reads first.
 - **Frontmatter on every note** — `title`, `tags`, `date`, `description`.
-- **Backlinks are project-scoped**: `[[tempo/technical/architecture/gotchas]]`, not `[[gotchas]]`. Keeps links unambiguous once you add more projects.
-- **`architecture/gotchas.md` is high-leverage** — put non-obvious traps there (the things that bite you in production), not in the main architecture docs.
+- **Wiki-links are project-scoped**: `[[tempo/gotchas/gotchas]]`, not `[[gotchas]]`. Keeps links unambiguous once you add more projects.
+- **Gotchas are first-class** — put non-obvious traps in `gotchas/`, not buried in design docs. They're what Claude needs to surface before suggesting changes.
 
-## Example Frontmatter
+## Example frontmatter
 
 ```markdown
 ---
 title: My Note Title
-tags: [project-name, architecture, firebase]
+tags: [project-name, adr, storage]
 date: 2026-04-17
 description: One-line summary used in search results and the index
 ---
@@ -48,13 +66,13 @@ description: One-line summary used in search results and the index
 # Note Content
 ```
 
-## Starting a New Project Drawer
+## Starting a new project
 
 1. `mkdir vault/new-project/`
 2. Create `vault/new-project/VAULT_SUMMARY.md` as the index
-3. Add subfolders as needed (`architecture/`, `features/`, etc.)
+3. Add type folders as needed (`adrs/`, `designs/`, `features/`, etc.)
 4. Point Claude at the new project by saving a memory or adding a line to the project's `CLAUDE.md`
 
-## Web UI (Optional)
+## Web UI (optional)
 
 The React app under `web/` renders the vault as a searchable graph. It needs `lib/server.js` running to index and serve notes. Claude itself does **not** need the backend — it reads markdown directly from disk.

--- a/vault/tempo/VAULT_SUMMARY.md
+++ b/vault/tempo/VAULT_SUMMARY.md
@@ -11,11 +11,16 @@ Everything you'd tell a new engineer about Tempo lives here. **Start with this f
 
 > Tempo is a fake product used as a demo vault. It's a focus/Pomodoro timer SaaS with a local-first desktop + web client. Nothing here is real.
 
-## 🗂️ Three Drawers
+## 🗂️ Folders
 
-- **`technical/`** — code, architecture, features, ADRs, gotchas
-- **`strategy/`** — research, product direction
-- **`business/`** — pricing, rollout
+One folder per content type. Each folder holds one kind of note so an LLM can jump straight to the right drawer without guessing.
+
+- **`adrs/`** — Architecture Decision Records (why a choice was made)
+- **`designs/`** — system/architecture designs (how it's built)
+- **`features/`** — user-facing feature specs (what the product does)
+- **`gotchas/`** — non-obvious traps worth reading before shipping
+- **`research/`** — market, user, and prior-art research
+- **`go-to-market/`** — pricing, positioning, rollout
 
 Top-level files (`overview.md`, `VAULT_SUMMARY.md`) stay at the root as entry points.
 
@@ -24,25 +29,27 @@ Top-level files (`overview.md`, `VAULT_SUMMARY.md`) stay at the root as entry po
 ### Root
 - [[tempo/overview]] — product summary, tech stack, quick start
 
-### Technical — Architecture
-- [[tempo/technical/architecture/frontend-architecture]] — React, Zustand, Web Workers, SQLite WASM
-- [[tempo/technical/architecture/gotchas]] — **read before shipping**: tab-throttling traps, SQLite WAL quirks
+### Designs
+- [[tempo/designs/frontend-architecture]] — React, Zustand, Web Workers, SQLite WASM
 
-### Technical — Features
-- [[tempo/technical/features/focus-sessions]] — the core "start a session" flow
+### Features
+- [[tempo/features/focus-sessions]] — the core "start a session" flow
 
-### Technical — Decisions (ADRs)
-- [[tempo/technical/decisions/adr-001-local-first-sqlite]] — why SQLite-in-browser over a cloud DB
-- [[tempo/technical/decisions/adr-002-web-workers-for-timers]] — why timers run in a Worker
+### ADRs
+- [[tempo/adrs/adr-001-local-first-sqlite]] — why SQLite-in-browser over a cloud DB
+- [[tempo/adrs/adr-002-web-workers-for-timers]] — why timers run in a Worker
 
-### Strategy
-- [[tempo/strategy/research/productivity-market-2026]] — focus-app landscape in 2026
+### Gotchas
+- [[tempo/gotchas/gotchas]] — **read before shipping**: tab-throttling traps, SQLite WAL quirks
 
-### Business
-- [[tempo/business/pricing]] — Free + Pro tiers, upgrade gates
+### Research
+- [[tempo/research/productivity-market-2026]] — focus-app landscape in 2026
+
+### Go-to-market
+- [[tempo/go-to-market/pricing]] — Free + Pro tiers, upgrade gates
 
 ## Conventions
 
-- Wiki-links are **project-scoped**: `[[tempo/technical/architecture/gotchas]]`, never `[[gotchas]]`.
+- Wiki-links are **project-scoped**: `[[tempo/gotchas/gotchas]]`, never `[[gotchas]]`.
 - Every note has frontmatter (`title`, `tags`, `date`, `description`).
-- Non-obvious traps go in `gotchas.md`, not mixed into architecture docs.
+- Non-obvious traps go in `gotchas/`, not mixed into design docs.

--- a/vault/tempo/adrs/adr-001-local-first-sqlite.md
+++ b/vault/tempo/adrs/adr-001-local-first-sqlite.md
@@ -21,7 +21,7 @@ We needed storage that:
 
 ## Decision
 
-Use **SQLite compiled to WASM**, persisted to **OPFS** (Origin Private File System). Sync is layered on top as an opt-in Pro feature — see [[tempo/business/pricing]] — that uploads encrypted snapshots to R2.
+Use **SQLite compiled to WASM**, persisted to **OPFS** (Origin Private File System). Sync is layered on top as an opt-in Pro feature — see [[tempo/go-to-market/pricing]] — that uploads encrypted snapshots to R2.
 
 The critical path — "start a session and write a tick" — never touches the network.
 
@@ -33,11 +33,11 @@ The critical path — "start a session and write a tick" — never touches the n
 - Users own their data by default. Exporting is a single `.sqlite` file.
 
 ### Bad
-- OPFS is newer and has gotchas — see [[tempo/technical/architecture/gotchas]] for the WAL corruption case we hit in beta.
+- OPFS is newer and has gotchas — see [[tempo/gotchas/gotchas]] for the WAL corruption case we hit in beta.
 - Cross-origin mounts are impossible. Two subdomains = two databases. We warn on boot if origin mismatches.
 - Sync conflict resolution is our problem, not the DB's. Current strategy: last-writer-wins per session, which is fine because sessions are append-only once ended.
 
 ### Related
-- Timer accounting that depends on this storage: [[tempo/technical/features/focus-sessions]]
-- The other major architectural choice: [[tempo/technical/decisions/adr-002-web-workers-for-timers]]
-- Integration details: [[tempo/technical/architecture/frontend-architecture]]
+- Timer accounting that depends on this storage: [[tempo/features/focus-sessions]]
+- The other major architectural choice: [[tempo/adrs/adr-002-web-workers-for-timers]]
+- Integration details: [[tempo/designs/frontend-architecture]]

--- a/vault/tempo/adrs/adr-002-web-workers-for-timers.md
+++ b/vault/tempo/adrs/adr-002-web-workers-for-timers.md
@@ -14,7 +14,7 @@ description: Why the Pomodoro tick loop runs in a dedicated Web Worker instead o
 
 First version of Tempo ran the tick loop with `setInterval` on the main thread. Reports started coming in: *"I backgrounded the tab for 25 minutes and when I came back my timer was at 9 minutes."*
 
-Root cause: Chrome and Firefox throttle timers in background tabs. `setInterval(1000)` becomes `setInterval(≥60000)` once the tab is hidden long enough. The timer doesn't pause — it just ticks slower than it claims to. This is [[tempo/technical/architecture/gotchas]] #1, written up after we got burned.
+Root cause: Chrome and Firefox throttle timers in background tabs. `setInterval(1000)` becomes `setInterval(≥60000)` once the tab is hidden long enough. The timer doesn't pause — it just ticks slower than it claims to. This is [[tempo/gotchas/gotchas]] #1, written up after we got burned.
 
 ## Decision
 
@@ -23,7 +23,7 @@ Move the tick loop to a **dedicated Web Worker**. Workers are throttled much les
 Architecture:
 - Worker computes elapsed time from a monotonic clock (`performance.now()` inside the Worker), not a naive counter.
 - Worker posts `{ remaining, phase }` messages at 1 Hz.
-- Main thread (React + Zustand — see [[tempo/technical/architecture/frontend-architecture]]) just renders the latest value.
+- Main thread (React + Zustand — see [[tempo/designs/frontend-architecture]]) just renders the latest value.
 
 ## Consequences
 
@@ -37,6 +37,6 @@ Architecture:
 - Workers can still be suspended if the browser reclaims memory. Rare, but possible. We detect this on resume and reconcile against `performance.now()`.
 
 ### Related
-- The feature using this timer: [[tempo/technical/features/focus-sessions]]
-- Storage decisions that interact with tick accounting: [[tempo/technical/decisions/adr-001-local-first-sqlite]]
-- Integration: [[tempo/technical/architecture/frontend-architecture]]
+- The feature using this timer: [[tempo/features/focus-sessions]]
+- Storage decisions that interact with tick accounting: [[tempo/adrs/adr-001-local-first-sqlite]]
+- Integration: [[tempo/designs/frontend-architecture]]

--- a/vault/tempo/designs/frontend-architecture.md
+++ b/vault/tempo/designs/frontend-architecture.md
@@ -17,8 +17,8 @@ Tempo is a single-page app, entirely client-side by default. No server round-tri
 ├────────────────────────────────┤
 │  Zustand store                 │  ← source of truth for UI state
 ├────────────────────────────────┤
-│  Timer Worker                  │  ← see [[tempo/technical/decisions/adr-002-web-workers-for-timers]]
-│  SQLite-WASM (OPFS)            │  ← see [[tempo/technical/decisions/adr-001-local-first-sqlite]]
+│  Timer Worker                  │  ← see [[tempo/adrs/adr-002-web-workers-for-timers]]
+│  SQLite-WASM (OPFS)            │  ← see [[tempo/adrs/adr-001-local-first-sqlite]]
 └────────────────────────────────┘
 ```
 
@@ -33,9 +33,9 @@ The store subscribes to messages from the Timer Worker (one message per second) 
 
 ## Known traps
 
-Before touching this code, skim [[tempo/technical/architecture/gotchas]]. The two biggest:
+Before touching this code, skim [[tempo/gotchas/gotchas]]. The two biggest:
 
-1. **Tab throttling** killed our first timer implementation. That's why [[tempo/technical/decisions/adr-002-web-workers-for-timers]] exists.
+1. **Tab throttling** killed our first timer implementation. That's why [[tempo/adrs/adr-002-web-workers-for-timers]] exists.
 2. **OPFS writes block the main thread** if you forget to use the async cursor. Always `await db.execAsync(...)`.
 
 ## Test strategy

--- a/vault/tempo/features/focus-sessions.md
+++ b/vault/tempo/features/focus-sessions.md
@@ -12,15 +12,15 @@ The user hits **Start**, a 25-minute timer begins, they work, a bell rings, they
 ## Flow
 
 1. User clicks **Start** → Zustand dispatches `startSession({ length: 25*60 })`.
-2. Store spins up the Timer Worker (if not already running) — see [[tempo/technical/decisions/adr-002-web-workers-for-timers]].
+2. Store spins up the Timer Worker (if not already running) — see [[tempo/adrs/adr-002-web-workers-for-timers]].
 3. Worker posts `{ remaining, phase: 'focus' }` at 1 Hz.
 4. UI renders. Store buffers ticks in memory.
-5. On completion: store writes a `sessions` row to SQLite — see [[tempo/technical/decisions/adr-001-local-first-sqlite]].
+5. On completion: store writes a `sessions` row to SQLite — see [[tempo/adrs/adr-001-local-first-sqlite]].
 6. UI transitions to a break phase. Repeat.
 
 ## Limits (by tier)
 
-Free users get 3 sessions per day. Pro users get unlimited and can customize durations. Details in [[tempo/business/pricing]]. The gate is enforced at step 1 — `startSession` throws `DailyLimitReached` if the user hits the cap.
+Free users get 3 sessions per day. Pro users get unlimited and can customize durations. Details in [[tempo/go-to-market/pricing]]. The gate is enforced at step 1 — `startSession` throws `DailyLimitReached` if the user hits the cap.
 
 ## Data model
 

--- a/vault/tempo/go-to-market/pricing.md
+++ b/vault/tempo/go-to-market/pricing.md
@@ -13,12 +13,12 @@ Two tiers. No enterprise tier yet — not enough signal to justify it.
 
 - Up to **3 focus sessions per day**
 - Fixed 25/5 durations (Pomodoro classic)
-- Local-only data (SQLite in the browser — see [[tempo/technical/decisions/adr-001-local-first-sqlite]])
+- Local-only data (SQLite in the browser — see [[tempo/adrs/adr-001-local-first-sqlite]])
 - History, tags, heatmap — all included
 
 The cap is daily, not monthly — we want people to hit it *frequently enough to feel it* but not so often they churn in frustration. 3/day landed after A/B testing 2 vs 3 vs 5.
 
-Gate enforcement lives in [[tempo/technical/features/focus-sessions]] at step 1 of the session-start flow.
+Gate enforcement lives in [[tempo/features/focus-sessions]] at step 1 of the session-start flow.
 
 ## Pro — $4/month or $36/year
 
@@ -32,7 +32,7 @@ Price chosen to be **lower than the perceived cost of a single distracting Twitt
 
 ## Why this works (we think)
 
-Research in [[tempo/strategy/research/productivity-market-2026]] suggests our target users will pay once they trust the tool. The free tier exists specifically to earn that trust — not to be a permanent resting point.
+Research in [[tempo/research/productivity-market-2026]] suggests our target users will pay once they trust the tool. The free tier exists specifically to earn that trust — not to be a permanent resting point.
 
 ## Checkout
 

--- a/vault/tempo/gotchas/gotchas.md
+++ b/vault/tempo/gotchas/gotchas.md
@@ -11,7 +11,7 @@ Small list, keeps growing.
 
 ## 1. `setTimeout` in a background tab is throttled to 1s minimum
 
-This is why the timer runs in a Worker — see [[tempo/technical/decisions/adr-002-web-workers-for-timers]]. If you see "drift" reports in Sentry, check that the session was started while the tab was foregrounded; that path has a different code branch.
+This is why the timer runs in a Worker — see [[tempo/adrs/adr-002-web-workers-for-timers]]. If you see "drift" reports in Sentry, check that the session was started while the tab was foregrounded; that path has a different code branch.
 
 ## 2. OPFS is same-origin only
 

--- a/vault/tempo/overview.md
+++ b/vault/tempo/overview.md
@@ -11,20 +11,20 @@ Tempo is a **focus timer** for people who bounce between tabs. A session runs in
 
 ## Stack
 
-- **Frontend:** React 19 + Vite + Zustand. See [[tempo/technical/architecture/frontend-architecture]].
-- **Storage:** SQLite compiled to WASM, persisted to OPFS. See [[tempo/technical/decisions/adr-001-local-first-sqlite]].
-- **Timer runtime:** dedicated Web Worker for drift-free tick accounting. See [[tempo/technical/decisions/adr-002-web-workers-for-timers]].
+- **Frontend:** React 19 + Vite + Zustand. See [[tempo/designs/frontend-architecture]].
+- **Storage:** SQLite compiled to WASM, persisted to OPFS. See [[tempo/adrs/adr-001-local-first-sqlite]].
+- **Timer runtime:** dedicated Web Worker for drift-free tick accounting. See [[tempo/adrs/adr-002-web-workers-for-timers]].
 - **Sync (Pro):** encrypted blobs to Cloudflare R2, keyed on a passphrase the user owns.
 
 ## Core flows
 
-1. **Start a focus session** — the main loop. Details in [[tempo/technical/features/focus-sessions]].
+1. **Start a focus session** — the main loop. Details in [[tempo/features/focus-sessions]].
 2. **Review history** — calendar heatmap + drill-down to individual sessions.
-3. **Sync across devices** (Pro only) — see [[tempo/business/pricing]] for tier gates.
+3. **Sync across devices** (Pro only) — see [[tempo/go-to-market/pricing]] for tier gates.
 
 ## Why it exists
 
-The focus-timer space is crowded but mostly cloud-first and account-gated. Tempo's pitch is *"start in one click, own your data."* Market context: [[tempo/strategy/research/productivity-market-2026]].
+The focus-timer space is crowded but mostly cloud-first and account-gated. Tempo's pitch is *"start in one click, own your data."* Market context: [[tempo/research/productivity-market-2026]].
 
 ## Quick start (dev)
 

--- a/vault/tempo/research/productivity-market-2026.md
+++ b/vault/tempo/research/productivity-market-2026.md
@@ -29,8 +29,8 @@ Through interviews (n=22, spring 2026) the segments that care are:
 
 ## Why now
 
-Browser capability unlocks (OPFS, stable Web Workers) make "local-first web app" viable without a native wrapper. Five years ago this product would've been a Tauri/Electron download. See [[tempo/technical/decisions/adr-001-local-first-sqlite]] for the tech that makes it work.
+Browser capability unlocks (OPFS, stable Web Workers) make "local-first web app" viable without a native wrapper. Five years ago this product would've been a Tauri/Electron download. See [[tempo/adrs/adr-001-local-first-sqlite]] for the tech that makes it work.
 
 ## Pricing implications
 
-Free tier has to be genuinely useful so users can validate the tool before paying. Pro is "sync + unlimited sessions + custom durations" — see [[tempo/business/pricing]] for the breakdown.
+Free tier has to be genuinely useful so users can validate the tool before paying. Pro is "sync + unlimited sessions + custom durations" — see [[tempo/go-to-market/pricing]] for the breakdown.

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -80,7 +80,7 @@ export function Sidebar({
 }: SidebarProps) {
   const [query, setQuery] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(
-    () => new Set(["tempo", "tempo/technical", "tempo/strategy", "tempo/business"])
+    () => new Set(["tempo", "tempo/adrs", "tempo/designs", "tempo/features", "tempo/gotchas", "tempo/research", "tempo/go-to-market"])
   );
 
   const tree = useMemo(() => buildTree(notes), [notes]);


### PR DESCRIPTION
## Summary

Replace the three audience-shaped drawers (`technical/`, `strategy/`, `business/`) with six type-shaped folders in the demo Tempo vault. Each folder now holds exactly one kind of note so an LLM asking *"why did we pick X"* or *"what can a free user do"* has a stable address to check without guessing.

| Before | After |
|---|---|
| `technical/architecture/frontend-architecture.md` | `designs/frontend-architecture.md` |
| `technical/architecture/gotchas.md` | `gotchas/gotchas.md` |
| `technical/decisions/adr-001-local-first-sqlite.md` | `adrs/adr-001-local-first-sqlite.md` |
| `technical/decisions/adr-002-web-workers-for-timers.md` | `adrs/adr-002-web-workers-for-timers.md` |
| `technical/features/focus-sessions.md` | `features/focus-sessions.md` |
| `strategy/research/productivity-market-2026.md` | `research/productivity-market-2026.md` |
| `business/pricing.md` | `go-to-market/pricing.md` |

### Why

Falls out of the [LLM-first documentation thesis](https://github.com/bernabranco/claude-code-vault/issues/33). Audience-shaped drawers (*"is this for engineers or for the business side?"*) require the reader to know the author's mental model before they can find anything. Type-shaped folders (*"is this an ADR, a gotcha, a feature spec?"*) are load-bearing metadata an LLM can rely on — the folder name **is** a stable anchor.

### What's in the commit

- **7 file moves** via `git mv` — history preserved per-file
- **Wiki-links updated** in all 9 vault markdown files (VAULT_SUMMARY, overview, pricing, focus-sessions, adr-001, adr-002, frontend-architecture, gotchas, productivity-market-2026)
- **`vault/README.md`** rewritten as a type-first conventions doc with folder-type table
- **Main `README.md`** Structure block, walkthrough example paths, and init description updated
- **`index.js` init scaffold** now creates the six new folders (`adrs/`, `designs/`, `features/`, `gotchas/`, `research/`, `go-to-market/`) and writes matching `VAULT_SUMMARY.md` / `overview.md` templates
- **`web/src/components/Sidebar.tsx`** default-expanded set updated to the new folder names

Zero changes to indexer, chunker, embeddings, MCP server, search logic, or graph — this is a pure folder refactor with keep-in-sync doc updates.

## Test plan

- [x] `node index.js check` — no new issues (4 pre-existing findings unchanged)
- [x] `rg -n 'tempo/(technical|strategy|business)'` — zero matches anywhere in repo
- [x] `rg -n 'gtm|GTM'` — zero matches anywhere in repo
- [ ] `node index.js reindex` on a user-facing vault works end-to-end
- [ ] `npx claude-code-vault init test-project` scaffolds the six new folders
- [ ] Web UI renders the tree with all six folders expanded by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)