### PR TITLE
feat(eval): retrieval eval harness with recall@5 + MRR@5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd web && npm install && cd ..
 
       - name: Type check (CLI)
-        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js
+        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js
 
       - name: Type check (web)
         run: cd web && npx tsc --noEmit && cd ..
@@ -43,6 +43,9 @@ jobs:
           node index.js --help
           node index.js index
           node index.js search "architecture" --limit 3
+
+      - name: Retrieval eval (recall@5 vs baseline)
+        run: node test/retrieval/eval.js --gate 5
 
       - name: Lint web (if eslintrc exists)
         run: cd web && npm run lint 2>/dev/null || echo "No lint script defined"

--- a/README.md
+++ b/README.md
@@ -226,6 +226,26 @@ Polish after the core is solid.
 - [ ] **[Public launch polish](https://github.com/bernabranco/claude-code-vault/issues/3)** — demo GIF, examples, comparison screenshots
 - [ ] **[Issue/PR templates](https://github.com/bernabranco/claude-code-vault/issues/6)** — `.github/` scaffolding
 
+## Evaluation
+
+Retrieval changes (semantic search, chunk search, future HyDE/filter work) are gated by an eval harness — `test/retrieval/eval.js` — that runs a hand-authored gold dataset through every search tool and reports `recall@5` and `MRR@5`. CI fails if a tool's recall@5 drops by more than **5pp** vs the committed baseline.
+
+```bash
+# Run the harness against the current code
+node test/retrieval/eval.js
+
+# Update the baseline after an intentional improvement
+node test/retrieval/eval.js --update-baseline
+
+# Tighten the regression gate
+node test/retrieval/eval.js --gate 2
+
+# Machine-readable output
+node test/retrieval/eval.js --json
+```
+
+The dataset (`test/retrieval/gold.json`) is hand-authored and tagged by category (`keyword-only`, `semantic-only`, `vocabulary-gap`, `graph-context`, `multi-section`) so a regression in one category is visible even when the overall number looks fine. Add new entries when shipping a note whose retrieval is non-obvious; never delete entries to make a metric look better.
+
 ## Contributing
 
 PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, the pre-PR CI checks, and workflow conventions. All contributors agree to the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/test/retrieval/baseline.json
+++ b/test/retrieval/baseline.json
@@ -1,0 +1,108 @@
+{
+  "generatedAt": "2026-04-19T20:47:23.673Z",
+  "queryCount": 20,
+  "summary": {
+    "keyword": {
+      "overall": {
+        "recallAt5": 0.2,
+        "mrrAt5": 0.2,
+        "count": 20
+      },
+      "byCategory": {
+        "keyword-only": {
+          "recallAt5": 1,
+          "mrrAt5": 1,
+          "count": 4
+        },
+        "semantic-only": {
+          "recallAt5": 0,
+          "mrrAt5": 0,
+          "count": 5
+        },
+        "vocabulary-gap": {
+          "recallAt5": 0,
+          "mrrAt5": 0,
+          "count": 4
+        },
+        "graph-context": {
+          "recallAt5": 0,
+          "mrrAt5": 0,
+          "count": 3
+        },
+        "multi-section": {
+          "recallAt5": 0,
+          "mrrAt5": 0,
+          "count": 4
+        }
+      }
+    },
+    "semantic": {
+      "overall": {
+        "recallAt5": 1,
+        "mrrAt5": 0.885,
+        "count": 20
+      },
+      "byCategory": {
+        "keyword-only": {
+          "recallAt5": 1,
+          "mrrAt5": 1,
+          "count": 4
+        },
+        "semantic-only": {
+          "recallAt5": 1,
+          "mrrAt5": 0.9,
+          "count": 5
+        },
+        "vocabulary-gap": {
+          "recallAt5": 1,
+          "mrrAt5": 0.875,
+          "count": 4
+        },
+        "graph-context": {
+          "recallAt5": 1,
+          "mrrAt5": 0.7333,
+          "count": 3
+        },
+        "multi-section": {
+          "recallAt5": 1,
+          "mrrAt5": 0.875,
+          "count": 4
+        }
+      }
+    },
+    "chunks": {
+      "overall": {
+        "recallAt5": 0.85,
+        "mrrAt5": 0.8,
+        "count": 20
+      },
+      "byCategory": {
+        "keyword-only": {
+          "recallAt5": 1,
+          "mrrAt5": 1,
+          "count": 4
+        },
+        "semantic-only": {
+          "recallAt5": 1,
+          "mrrAt5": 0.9,
+          "count": 5
+        },
+        "vocabulary-gap": {
+          "recallAt5": 1,
+          "mrrAt5": 0.875,
+          "count": 4
+        },
+        "graph-context": {
+          "recallAt5": 0.6667,
+          "mrrAt5": 0.6667,
+          "count": 3
+        },
+        "multi-section": {
+          "recallAt5": 0.5,
+          "mrrAt5": 0.5,
+          "count": 4
+        }
+      }
+    }
+  }
+}

--- a/test/retrieval/eval.js
+++ b/test/retrieval/eval.js
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * Retrieval eval harness — issue #15.
+ *
+ * Runs every gold query against keyword / semantic / chunk search and
+ * reports recall@5 + MRR@5. Compares against test/retrieval/baseline.json
+ * if present, exits non-zero when a tool's recall@5 drops by more than
+ * the gate (default 5pp).
+ *
+ * Usage:
+ *   node test/retrieval/eval.js                  # eval + diff vs baseline
+ *   node test/retrieval/eval.js --update-baseline
+ *   node test/retrieval/eval.js --gate 10        # tolerate up to 10pp drop
+ *   node test/retrieval/eval.js --json           # machine-readable output
+ *   node test/retrieval/eval.js --vault ./vault  # override vault dir
+ */
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+import { Vault } from "../../lib/vault.js";
+import {
+  openEmbeddingsDb,
+  syncEmbeddings,
+  semanticSearch,
+  searchChunks,
+} from "../../lib/embeddings.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const K = 5;
+
+function parseArgs(argv) {
+  const args = {
+    updateBaseline: false,
+    gate: 5,
+    json: false,
+    vault: path.resolve(__dirname, "..", "..", "vault"),
+    gold: path.join(__dirname, "gold.json"),
+    baseline: path.join(__dirname, "baseline.json"),
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--update-baseline") args.updateBaseline = true;
+    else if (a === "--json") args.json = true;
+    else if (a === "--gate") args.gate = Number(argv[++i]);
+    else if (a === "--vault") args.vault = path.resolve(argv[++i]);
+    else if (a === "--gold") args.gold = path.resolve(argv[++i]);
+    else if (a === "--baseline") args.baseline = path.resolve(argv[++i]);
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: node test/retrieval/eval.js [--update-baseline] [--gate N] [--json] [--vault DIR] [--gold FILE] [--baseline FILE]",
+      );
+      process.exit(0);
+    } else {
+      console.error(`Unknown arg: ${a}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function rankOfNote(results, expectedNoteId, idKey) {
+  for (let i = 0; i < results.length; i++) {
+    if (results[i][idKey] === expectedNoteId) return i + 1;
+  }
+  return null;
+}
+
+function chunkRankMatching(results, expectedNoteId, expectedChunkHeading) {
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r.noteId !== expectedNoteId) continue;
+    if (!expectedChunkHeading) return i + 1;
+    const heading = r.headingPath?.[r.headingPath.length - 1];
+    if (heading === expectedChunkHeading) return i + 1;
+  }
+  return null;
+}
+
+function aggregate(perQuery) {
+  const total = perQuery.length;
+  if (total === 0) return { recallAt5: 0, mrrAt5: 0, count: 0 };
+  let hits = 0;
+  let mrrSum = 0;
+  for (const q of perQuery) {
+    if (q.rank !== null) {
+      hits++;
+      mrrSum += 1 / q.rank;
+    }
+  }
+  return {
+    recallAt5: Number((hits / total).toFixed(4)),
+    mrrAt5: Number((mrrSum / total).toFixed(4)),
+    count: total,
+  };
+}
+
+function aggregateByCategory(perQuery) {
+  const byCat = new Map();
+  for (const q of perQuery) {
+    if (!byCat.has(q.category)) byCat.set(q.category, []);
+    byCat.get(q.category).push(q);
+  }
+  const out = {};
+  for (const [cat, qs] of byCat) out[cat] = aggregate(qs);
+  return out;
+}
+
+async function runEval(opts) {
+  const goldRaw = JSON.parse(fs.readFileSync(opts.gold, "utf8"));
+  const queries = goldRaw.queries;
+  if (!Array.isArray(queries) || queries.length === 0) {
+    throw new Error(`No queries found in ${opts.gold}`);
+  }
+
+  const vault = new Vault(opts.vault);
+  await vault.reindex();
+
+  const dbPath = path.join(os.tmpdir(), `vault-eval-${process.pid}.db`);
+  if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+  const db = openEmbeddingsDb(dbPath);
+
+  if (!opts.json) {
+    process.stderr.write(
+      `[eval] vault=${opts.vault} notes=${vault.index.length} queries=${queries.length}\n`,
+    );
+    process.stderr.write(`[eval] embedding chunks (one-time)...\n`);
+  }
+  await syncEmbeddings(db, vault);
+
+  const perTool = {
+    keyword: [],
+    semantic: [],
+    chunks: [],
+  };
+
+  for (const q of queries) {
+    const baseEntry = {
+      query: q.query,
+      expectedNoteId: q.expectedNoteId,
+      expectedChunkHeading: q.expectedChunkHeading ?? null,
+      category: q.category ?? "uncategorized",
+    };
+
+    const kwResults = vault.search(q.query).slice(0, K);
+    perTool.keyword.push({
+      ...baseEntry,
+      rank: rankOfNote(kwResults, q.expectedNoteId, "id"),
+    });
+
+    const semResults = await semanticSearch(db, vault, q.query, K);
+    perTool.semantic.push({
+      ...baseEntry,
+      rank: rankOfNote(semResults, q.expectedNoteId, "id"),
+    });
+
+    const chunkResults = await searchChunks(db, vault, q.query, K);
+    perTool.chunks.push({
+      ...baseEntry,
+      rank: chunkRankMatching(
+        chunkResults,
+        q.expectedNoteId,
+        q.expectedChunkHeading,
+      ),
+    });
+  }
+
+  db.close();
+  try { fs.unlinkSync(dbPath); } catch {}
+
+  const summary = {};
+  for (const [tool, perQuery] of Object.entries(perTool)) {
+    summary[tool] = {
+      overall: aggregate(perQuery),
+      byCategory: aggregateByCategory(perQuery),
+    };
+  }
+  return { perTool, summary, queryCount: queries.length };
+}
+
+function fmtPct(n) {
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function printHumanReport(result, baseline) {
+  const tools = Object.keys(result.summary);
+  console.log("\nRetrieval eval — recall@5 / MRR@5");
+  console.log("=".repeat(72));
+  console.log(
+    "Tool".padEnd(12) +
+      "Recall@5".padEnd(12) +
+      "MRR@5".padEnd(10) +
+      "Δrecall".padEnd(10) +
+      "ΔMRR".padEnd(10),
+  );
+  console.log("-".repeat(72));
+  for (const tool of tools) {
+    const cur = result.summary[tool].overall;
+    const base = baseline?.summary?.[tool]?.overall;
+    const dRecall = base ? cur.recallAt5 - base.recallAt5 : null;
+    const dMrr = base ? cur.mrrAt5 - base.mrrAt5 : null;
+    console.log(
+      tool.padEnd(12) +
+        fmtPct(cur.recallAt5).padEnd(12) +
+        cur.mrrAt5.toFixed(3).padEnd(10) +
+        (dRecall === null ? "—".padEnd(10) : fmtDelta(dRecall, true).padEnd(10)) +
+        (dMrr === null ? "—".padEnd(10) : fmtDelta(dMrr, false).padEnd(10)),
+    );
+  }
+  console.log("=".repeat(72));
+
+  console.log("\nBy category (recall@5):");
+  const cats = new Set();
+  for (const tool of tools) {
+    for (const c of Object.keys(result.summary[tool].byCategory)) cats.add(c);
+  }
+  const sortedCats = [...cats].sort();
+  console.log(
+    "Category".padEnd(20) + tools.map((t) => t.padEnd(12)).join(""),
+  );
+  console.log("-".repeat(20 + tools.length * 12));
+  for (const cat of sortedCats) {
+    const row =
+      cat.padEnd(20) +
+      tools
+        .map((t) => {
+          const m = result.summary[t].byCategory[cat];
+          return (m ? fmtPct(m.recallAt5) : "—").padEnd(12);
+        })
+        .join("");
+    console.log(row);
+  }
+  console.log();
+}
+
+function fmtDelta(n, isPct) {
+  if (Math.abs(n) < 0.0001) return "  0.0";
+  const sign = n > 0 ? "+" : "";
+  return isPct ? `${sign}${(n * 100).toFixed(1)}pp` : `${sign}${n.toFixed(3)}`;
+}
+
+function checkRegression(result, baseline, gatePp) {
+  if (!baseline) return { ok: true, regressions: [] };
+  const regressions = [];
+  for (const tool of Object.keys(result.summary)) {
+    const cur = result.summary[tool].overall.recallAt5;
+    const base = baseline.summary?.[tool]?.overall?.recallAt5;
+    if (base === undefined) continue;
+    const dropPp = (base - cur) * 100;
+    if (dropPp > gatePp) {
+      regressions.push({ tool, basePct: base * 100, curPct: cur * 100, dropPp });
+    }
+  }
+  return { ok: regressions.length === 0, regressions };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  const result = await runEval(opts);
+
+  let baseline = null;
+  if (fs.existsSync(opts.baseline)) {
+    baseline = JSON.parse(fs.readFileSync(opts.baseline, "utf8"));
+  }
+
+  if (opts.updateBaseline) {
+    const out = {
+      generatedAt: new Date().toISOString(),
+      queryCount: result.queryCount,
+      summary: result.summary,
+    };
+    fs.writeFileSync(opts.baseline, JSON.stringify(out, null, 2) + "\n");
+    process.stderr.write(`[eval] baseline written to ${opts.baseline}\n`);
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify({ result: result.summary, baseline: baseline?.summary ?? null }, null, 2));
+  } else {
+    printHumanReport(result, baseline);
+  }
+
+  if (!opts.updateBaseline) {
+    const { ok, regressions } = checkRegression(result, baseline, opts.gate);
+    if (!ok) {
+      console.error(
+        `\n✗ Regression: ${regressions.length} tool(s) dropped recall@5 by more than ${opts.gate}pp`,
+      );
+      for (const r of regressions) {
+        console.error(
+          `  ${r.tool}: ${r.basePct.toFixed(1)}% → ${r.curPct.toFixed(1)}% (-${r.dropPp.toFixed(1)}pp)`,
+        );
+      }
+      process.exit(1);
+    }
+    if (baseline) console.log("✓ No retrieval regression.");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/retrieval/gold.json
+++ b/test/retrieval/gold.json
@@ -1,0 +1,109 @@
+{
+  "$comment": "Hand-authored gold dataset for retrieval eval. Add entries when shipping notes whose retrieval is non-obvious; never delete entries to make a metric look better. Categories: keyword-only (matches title/tag/id), semantic-only (needs body semantics), vocabulary-gap (HyDE target), graph-context (needs neighbor expansion), multi-section (chunk-level scoring).",
+  "queries": [
+    {
+      "query": "ADR-001",
+      "expectedNoteId": "tempo/adrs/adr-001-local-first-sqlite",
+      "category": "keyword-only"
+    },
+    {
+      "query": "pricing",
+      "expectedNoteId": "tempo/go-to-market/pricing",
+      "category": "keyword-only"
+    },
+    {
+      "query": "gotchas",
+      "expectedNoteId": "tempo/gotchas/gotchas",
+      "category": "keyword-only"
+    },
+    {
+      "query": "frontend architecture",
+      "expectedNoteId": "tempo/designs/frontend-architecture",
+      "category": "keyword-only"
+    },
+    {
+      "query": "how do we keep the timer accurate when the tab is in the background",
+      "expectedNoteId": "tempo/adrs/adr-002-web-workers-for-timers",
+      "category": "semantic-only"
+    },
+    {
+      "query": "what happens if a user closes the tab mid-session",
+      "expectedNoteId": "tempo/features/focus-sessions",
+      "category": "semantic-only"
+    },
+    {
+      "query": "what is our policy on storing user data offline",
+      "expectedNoteId": "tempo/adrs/adr-001-local-first-sqlite",
+      "category": "semantic-only"
+    },
+    {
+      "query": "free tier daily session limit",
+      "expectedNoteId": "tempo/go-to-market/pricing",
+      "category": "semantic-only"
+    },
+    {
+      "query": "user research segments and interview findings",
+      "expectedNoteId": "tempo/research/productivity-market-2026",
+      "category": "semantic-only"
+    },
+    {
+      "query": "why did we pick local DB",
+      "expectedNoteId": "tempo/adrs/adr-001-local-first-sqlite",
+      "category": "vocabulary-gap"
+    },
+    {
+      "query": "how do we prevent timer drift",
+      "expectedNoteId": "tempo/adrs/adr-002-web-workers-for-timers",
+      "category": "vocabulary-gap"
+    },
+    {
+      "query": "where does the database live",
+      "expectedNoteId": "tempo/adrs/adr-001-local-first-sqlite",
+      "category": "vocabulary-gap"
+    },
+    {
+      "query": "is data sent to a server",
+      "expectedNoteId": "tempo/adrs/adr-001-local-first-sqlite",
+      "category": "vocabulary-gap"
+    },
+    {
+      "query": "what tradeoffs come with our storage choice",
+      "expectedNoteId": "tempo/adrs/adr-001-local-first-sqlite",
+      "category": "graph-context"
+    },
+    {
+      "query": "how does pricing relate to session limits",
+      "expectedNoteId": "tempo/features/focus-sessions",
+      "category": "graph-context"
+    },
+    {
+      "query": "what should I read before touching timer code",
+      "expectedNoteId": "tempo/gotchas/gotchas",
+      "category": "graph-context"
+    },
+    {
+      "query": "OPFS WAL corruption on force close",
+      "expectedNoteId": "tempo/gotchas/gotchas",
+      "expectedChunkHeading": "3. SQLite WAL mode + OPFS = corruption risk on force-close",
+      "category": "multi-section"
+    },
+    {
+      "query": "Zustand HMR subscription leak",
+      "expectedNoteId": "tempo/gotchas/gotchas",
+      "expectedChunkHeading": "4. Zustand subscriptions leak across HMR",
+      "category": "multi-section"
+    },
+    {
+      "query": "what is the decision recorded in ADR-001",
+      "expectedNoteId": "tempo/adrs/adr-001-local-first-sqlite",
+      "expectedChunkHeading": "Decision",
+      "category": "multi-section"
+    },
+    {
+      "query": "tempo's stack and tech choices",
+      "expectedNoteId": "tempo/overview",
+      "expectedChunkHeading": "Stack",
+      "category": "multi-section"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #15.

## Summary

Hand-authored gold dataset of **20 queries** across five retrieval categories (keyword-only, semantic-only, vocabulary-gap, graph-context, multi-section). The eval script runs every query through `vault.search` (keyword), `semanticSearch` (note-level), and `searchChunks` (chunk-level); reports `recall@5` and `MRR@5` per tool and per category; diffs against a committed baseline.

Wired into CI as a regression gate — a tool dropping `recall@5` by more than **5pp** vs baseline fails the run.

## Why

Issues #16 (HyDE) and #17 (filter-before-rank) both have acceptance criteria of the form *"eval harness shows lift"*. This PR is the prerequisite that makes those landable without guessing.

## Initial baseline (tempo vault, 10 notes, 20 queries)

| Tool | Recall@5 | MRR@5 |
|---|---|---|
| keyword | 20.0% | 0.200 |
| semantic | 100% | 0.885 |
| chunks | 85% | 0.800 |

Per-category breakdown is in `test/retrieval/baseline.json`. The 20% keyword number is correct — `vault.search` only matches title/tag/id, not body, so it only hits on the 4 keyword-only queries (which it gets 100%). That's the signal HyDE/filters are designed to lift.

## How to use

```bash
node test/retrieval/eval.js                  # eval + diff vs baseline
node test/retrieval/eval.js --update-baseline
node test/retrieval/eval.js --gate 2         # tighten regression gate
node test/retrieval/eval.js --json           # machine-readable
```

## Files

- `test/retrieval/gold.json` — 20 hand-authored queries, categorized
- `test/retrieval/eval.js` — runner, supports `--update-baseline`, `--gate`, `--json`, `--vault`, `--gold`, `--baseline` flags
- `test/retrieval/baseline.json` — committed baseline (regenerate with `--update-baseline` after intentional improvements)
- `.github/workflows/ci.yml` — new step "Retrieval eval (recall@5 vs baseline)"; eval script also added to type-check
- `README.md` — new "Evaluation" section explaining the workflow

## Test plan

- [x] `node test/retrieval/eval.js --update-baseline` regenerates baseline cleanly
- [x] `node test/retrieval/eval.js` re-run reports zero delta on every tool, exits 0
- [x] Type-check passes (`tsc --noEmit --allowJs --skipLibCheck`) including `test/retrieval/eval.js`
- [x] Categories tagged so future regressions are visible per-category, not just overall
- [ ] CI green on Node 20.x and 22.x matrix