### PR TITLE
feat(embeddings): pre-filter by folder/tag/date before vector search (#17)

### DIFF
--- a/index.js
+++ b/index.js
@@ -507,7 +507,7 @@ async function openSyncedDb() {
 
   const cacheDir = path.resolve(vaultDir, "..", ".vault-cache");
   await fs.mkdir(cacheDir, { recursive: true });
-  const db = openEmbeddingsDb(path.join(cacheDir, "embeddings.db"));
+  const db = openEmbeddingsDb(path.join(cacheDir, "embeddings-v2.db"));
 
   console.error("Syncing embeddings...");
   const stats = await syncEmbeddings(db, vault);
@@ -522,13 +522,22 @@ async function openSyncedDb() {
 program
   .command("semantic-search <query>")
   .option("--limit <n>", "Max results", "10")
+  .option("--folder <path>", "Restrict to note ids under this folder prefix")
+  .option("--tag <tag...>", "Restrict to notes with any of these tags")
+  .option("--after <date>", "Restrict to notes with frontmatter date >= YYYY-MM-DD")
+  .option("--before <date>", "Restrict to notes with frontmatter date <= YYYY-MM-DD")
   .option("--json", "Output as JSON")
   .description("Search vault by meaning (note-level, local embeddings)")
   .action(async (query, options) => {
     const { semanticSearch } = await import("./lib/embeddings.js");
     const { db, vault } = await openSyncedDb();
-    const limit = parseInt(options.limit);
-    const results = await semanticSearch(db, vault, query, limit);
+    const results = await semanticSearch(db, vault, query, {
+      limit: parseInt(options.limit),
+      folder: options.folder,
+      tag: options.tag,
+      after: options.after,
+      before: options.before,
+    });
     db.close();
 
     if (options.json) {
@@ -545,13 +554,22 @@ program
 program
   .command("search-chunks <query>")
   .option("--limit <n>", "Max results", "5")
+  .option("--folder <path>", "Restrict to note ids under this folder prefix")
+  .option("--tag <tag...>", "Restrict to notes with any of these tags")
+  .option("--after <date>", "Restrict to notes with frontmatter date >= YYYY-MM-DD")
+  .option("--before <date>", "Restrict to notes with frontmatter date <= YYYY-MM-DD")
   .option("--json", "Output as JSON")
   .description("Search vault at paragraph/section level (chunk retrieval)")
   .action(async (query, options) => {
     const { searchChunks } = await import("./lib/embeddings.js");
     const { db, vault } = await openSyncedDb();
-    const limit = parseInt(options.limit);
-    const results = await searchChunks(db, vault, query, limit);
+    const results = await searchChunks(db, vault, query, {
+      limit: parseInt(options.limit),
+      folder: options.folder,
+      tag: options.tag,
+      after: options.after,
+      before: options.before,
+    });
     db.close();
 
     if (options.json) {
@@ -636,14 +654,23 @@ program
   .option("--limit <n>", "Max chunk results", "5")
   .option("--depth <n>", "Neighbor hop depth (1 or 2)", "1")
   .option("--max-chars <n>", "Budget for neighbor snippets", "8000")
+  .option("--folder <path>", "Restrict to note ids under this folder prefix")
+  .option("--tag <tag...>", "Restrict to notes with any of these tags")
+  .option("--after <date>", "Restrict to notes with frontmatter date >= YYYY-MM-DD")
+  .option("--before <date>", "Restrict to notes with frontmatter date <= YYYY-MM-DD")
   .option("--json", "Output as JSON")
   .description("Search chunks and include graph neighbors of hit notes")
   .action(async (query, options) => {
     const { searchChunks } = await import("./lib/embeddings.js");
     const { expandNeighbors } = await import("./lib/graph.js");
     const { db, vault } = await openSyncedDb();
-    const limit = parseInt(options.limit);
-    const chunks = await searchChunks(db, vault, query, limit);
+    const chunks = await searchChunks(db, vault, query, {
+      limit: parseInt(options.limit),
+      folder: options.folder,
+      tag: options.tag,
+      after: options.after,
+      before: options.before,
+    });
     const anchorIds = [...new Set(chunks.map((c) => c.noteId))];
     const { neighbors, truncated } =
       anchorIds.length > 0

--- a/lib/embeddings.js
+++ b/lib/embeddings.js
@@ -37,9 +37,12 @@ export function openEmbeddingsDb(dbPath) {
       heading_path TEXT NOT NULL,
       text         TEXT NOT NULL,
       links        TEXT NOT NULL,
+      tags_json    TEXT NOT NULL DEFAULT '[]',
+      note_date    TEXT,
       UNIQUE(note_id, chunk_idx)
     );
     CREATE INDEX IF NOT EXISTS idx_note_chunks_note_id ON note_chunks(note_id);
+    CREATE INDEX IF NOT EXISTS idx_note_chunks_date ON note_chunks(note_date);
     CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(
       rowid     INTEGER PRIMARY KEY,
       embedding FLOAT[${EMBED_DIMS}] distance_metric=cosine
@@ -48,7 +51,7 @@ export function openEmbeddingsDb(dbPath) {
   return db;
 }
 
-async function replaceChunksForNote(db, noteId, chunks) {
+async function replaceChunksForNote(db, noteId, chunks, noteMeta = {}) {
   const existingRowids = db
     .prepare("SELECT rowid FROM note_chunks WHERE note_id = ?")
     .all(noteId)
@@ -61,11 +64,14 @@ async function replaceChunksForNote(db, noteId, chunks) {
   }
 
   const insertChunk = db.prepare(
-    "INSERT INTO note_chunks(note_id, chunk_idx, heading_path, text, links) VALUES (?, ?, ?, ?, ?) RETURNING rowid"
+    "INSERT INTO note_chunks(note_id, chunk_idx, heading_path, text, links, tags_json, note_date) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING rowid"
   );
   const insertVec = db.prepare(
     "INSERT INTO vec_chunks(rowid, embedding) VALUES (?, ?)"
   );
+
+  const tagsJson = JSON.stringify(noteMeta.tags ?? []);
+  const noteDate = noteMeta.date ?? null;
 
   for (const ch of chunks) {
     const breadcrumb = ch.heading_path.join(" > ");
@@ -76,7 +82,9 @@ async function replaceChunksForNote(db, noteId, chunks) {
       ch.chunk_idx,
       JSON.stringify(ch.heading_path),
       ch.text,
-      JSON.stringify(ch.links)
+      JSON.stringify(ch.links),
+      tagsJson,
+      noteDate
     );
     insertVec.run(BigInt(rowid), vec);
   }
@@ -103,7 +111,10 @@ export async function syncEmbeddings(db, vault) {
     const filePath = path.join(vault.vaultDir, note.path);
     const raw = await fs.readFile(filePath, "utf-8");
     const chunks = chunkMarkdown(raw, note.title);
-    await replaceChunksForNote(db, note.id, chunks);
+    await replaceChunksForNote(db, note.id, chunks, {
+      tags: note.tags,
+      date: note.frontmatter?.date ?? null,
+    });
     upsertMeta.run(note.id, note.lastModified);
     reembedded++;
     totalChunks += chunks.length;
@@ -128,20 +139,72 @@ export async function syncEmbeddings(db, vault) {
   };
 }
 
-export async function searchChunks(db, vault, query, limit = 5) {
+/**
+ * Build the rowid pre-filter SQL + bind values from filter options.
+ * Returns { sql: " AND rowid IN (...)" or "", binds: [] }.
+ *
+ * Filters are AND-combined across fields; within `tag` (when array), entries
+ * are OR-combined (any-match).
+ */
+function buildFilterClause(filters) {
+  const where = [];
+  const binds = [];
+
+  if (filters.folder) {
+    const folder = String(filters.folder);
+    const prefix = folder.endsWith("/") ? folder : folder + "/";
+    where.push("(note_id = ? OR note_id LIKE ?)");
+    binds.push(folder, prefix + "%");
+  }
+
+  if (filters.tag) {
+    const tags = Array.isArray(filters.tag) ? filters.tag : [filters.tag];
+    if (tags.length > 0) {
+      const placeholders = tags.map(() => "?").join(", ");
+      where.push(
+        `EXISTS (SELECT 1 FROM json_each(tags_json) WHERE value IN (${placeholders}))`
+      );
+      binds.push(...tags.map(String));
+    }
+  }
+
+  if (filters.after) {
+    where.push("note_date >= ?");
+    binds.push(String(filters.after));
+  }
+
+  if (filters.before) {
+    where.push("note_date <= ?");
+    binds.push(String(filters.before));
+  }
+
+  if (where.length === 0) return { sql: "", binds: [] };
+  const inner = `SELECT rowid FROM note_chunks WHERE ${where.join(" AND ")}`;
+  return { sql: ` AND rowid IN (${inner})`, binds };
+}
+
+function normalizeOpts(optsOrLimit, defaultLimit) {
+  if (optsOrLimit == null) return { limit: defaultLimit };
+  if (typeof optsOrLimit === "number") return { limit: optsOrLimit };
+  return { limit: defaultLimit, ...optsOrLimit };
+}
+
+export async function searchChunks(db, vault, query, optsOrLimit) {
+  const opts = normalizeOpts(optsOrLimit, 5);
   const queryVec = await embedText(query);
-  const rows = db
-    .prepare(
-      `
+  const filter = buildFilterClause(opts);
+  const sql = `
     SELECT c.note_id, c.chunk_idx, c.heading_path, c.text, c.links, v.distance
-    FROM vec_chunks v
+    FROM (
+      SELECT rowid, distance FROM vec_chunks
+      WHERE embedding MATCH ?
+        AND k = ?${filter.sql}
+      ORDER BY distance
+    ) v
     JOIN note_chunks c ON c.rowid = v.rowid
-    WHERE v.embedding MATCH ?
-      AND k = ?
     ORDER BY v.distance
-  `
-    )
-    .all(queryVec, limit);
+  `;
+  const rows = db.prepare(sql).all(queryVec, opts.limit, ...filter.binds);
 
   return rows.map((r) => {
     const note = vault.index.find((n) => n.id === r.note_id);
@@ -157,8 +220,12 @@ export async function searchChunks(db, vault, query, limit = 5) {
   });
 }
 
-export async function semanticSearch(db, vault, query, limit = 10) {
-  const chunkHits = await searchChunks(db, vault, query, limit * 4);
+export async function semanticSearch(db, vault, query, optsOrLimit) {
+  const opts = normalizeOpts(optsOrLimit, 10);
+  const chunkHits = await searchChunks(db, vault, query, {
+    ...opts,
+    limit: opts.limit * 4,
+  });
   const byNote = new Map();
   for (const hit of chunkHits) {
     const prev = byNote.get(hit.noteId);
@@ -168,7 +235,7 @@ export async function semanticSearch(db, vault, query, limit = 10) {
   }
   const ranked = [...byNote.values()]
     .sort((a, b) => b.similarity - a.similarity)
-    .slice(0, limit);
+    .slice(0, opts.limit);
 
   return ranked.map((hit) => {
     const note = vault.index.find((n) => n.id === hit.noteId);

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -27,7 +27,7 @@ try {
   semanticSearch = mod.semanticSearch;
   searchChunks = mod.searchChunks;
   expandNeighbors = graphMod.expandNeighbors;
-  embeddingsDb = mod.openEmbeddingsDb(path.join(cacheDir, "embeddings.db"));
+  embeddingsDb = mod.openEmbeddingsDb(path.join(cacheDir, "embeddings-v2.db"));
   embeddingsReady = syncEmbeddings(embeddingsDb, vault).catch((e) => {
     console.error("initial embedding sync failed:", e);
     embeddingsDb = null;
@@ -174,13 +174,17 @@ if (embeddingsDb) {
     "vault_semantic_search",
     {
       description:
-        "Search vault notes by meaning, not exact keywords. Returns notes ranked by cosine similarity of their best-matching chunk to the query, along with the heading path of that best chunk. Use when looking for notes *about* a concept (e.g. 'notes about authentication'). Pair with vault_read when you need the full note, or vault_search_chunks when you only need the most relevant paragraphs.",
+        "Search vault notes by meaning, not exact keywords. Returns notes ranked by cosine similarity of their best-matching chunk to the query, along with the heading path of that best chunk. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Use when looking for notes *about* a concept (e.g. 'notes about authentication'). Pair with vault_read when you need the full note, or vault_search_chunks when you only need the most relevant paragraphs.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
+        folder: z.string().optional(),
+        tag: z.union([z.string(), z.array(z.string())]).optional(),
+        after: z.string().optional(),
+        before: z.string().optional(),
       },
     },
-    safe(async ({ query, limit }) => {
+    safe(async ({ query, limit, folder, tag, after, before }) => {
       await embeddingsReady;
       if (!embeddingsDb) {
         return {
@@ -188,7 +192,13 @@ if (embeddingsDb) {
           content: [{ type: "text", text: "Semantic search unavailable (initial sync failed)." }],
         };
       }
-      const results = await semanticSearch(embeddingsDb, vault, query, limit ?? 10);
+      const results = await semanticSearch(embeddingsDb, vault, query, {
+        limit: limit ?? 10,
+        folder,
+        tag,
+        after,
+        before,
+      });
       return {
         content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
       };
@@ -199,13 +209,17 @@ if (embeddingsDb) {
     "vault_search_chunks",
     {
       description:
-        "Search vault at the paragraph/section level. Returns the most semantically similar chunks (not whole notes), each with its heading breadcrumb (e.g. 'ADR-001 > Rationale > Why Workers'), the chunk text itself, any wiki-links it contains, and a similarity score. Use this when you want just the relevant passage — much cheaper than reading whole notes. Follow up with vault_read if the surrounding file context matters.",
+        "Search vault at the paragraph/section level. Returns the most semantically similar chunks (not whole notes), each with its heading breadcrumb (e.g. 'ADR-001 > Rationale > Why Workers'), the chunk text itself, any wiki-links it contains, and a similarity score. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Use this when you want just the relevant passage — much cheaper than reading whole notes. Follow up with vault_read if the surrounding file context matters.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
+        folder: z.string().optional(),
+        tag: z.union([z.string(), z.array(z.string())]).optional(),
+        after: z.string().optional(),
+        before: z.string().optional(),
       },
     },
-    safe(async ({ query, limit }) => {
+    safe(async ({ query, limit, folder, tag, after, before }) => {
       await embeddingsReady;
       if (!embeddingsDb) {
         return {
@@ -213,7 +227,13 @@ if (embeddingsDb) {
           content: [{ type: "text", text: "Chunk search unavailable (initial sync failed)." }],
         };
       }
-      const results = await searchChunks(embeddingsDb, vault, query, limit ?? 5);
+      const results = await searchChunks(embeddingsDb, vault, query, {
+        limit: limit ?? 5,
+        folder,
+        tag,
+        after,
+        before,
+      });
       return {
         content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
       };
@@ -274,15 +294,19 @@ if (embeddingsDb) {
     "vault_search_chunks_with_context",
     {
       description:
-        "Like vault_search_chunks but also returns graph neighbors of the notes whose chunks were hit. For each chunk result you get the usual (text, heading breadcrumb, links, similarity); additionally a `neighbors` array lists notes linked from those chunks, ranked by edge weight (bidirectional first, then link frequency, then recency). Use when a query needs both the passage and the surrounding graph context. maxChars caps total neighbor-snippet bytes.",
+        "Like vault_search_chunks but also returns graph neighbors of the notes whose chunks were hit. For each chunk result you get the usual (text, heading breadcrumb, links, similarity); additionally a `neighbors` array lists notes linked from those chunks, ranked by edge weight (bidirectional first, then link frequency, then recency). Supports the same pre-filters as vault_search_chunks (`folder`, `tag`, `after`, `before`) — filters are applied to the chunk search stage, not to neighbor expansion. Use when a query needs both the passage and the surrounding graph context. maxChars caps total neighbor-snippet bytes.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
         depth: z.number().int().min(1).max(2).optional(),
         maxChars: z.number().int().positive().optional(),
+        folder: z.string().optional(),
+        tag: z.union([z.string(), z.array(z.string())]).optional(),
+        after: z.string().optional(),
+        before: z.string().optional(),
       },
     },
-    safe(async ({ query, limit, depth, maxChars }) => {
+    safe(async ({ query, limit, depth, maxChars, folder, tag, after, before }) => {
       await embeddingsReady;
       if (!embeddingsDb) {
         return {
@@ -290,7 +314,13 @@ if (embeddingsDb) {
           content: [{ type: "text", text: "Graph expansion unavailable (embeddings not ready)." }],
         };
       }
-      const chunks = await searchChunks(embeddingsDb, vault, query, limit ?? 5);
+      const chunks = await searchChunks(embeddingsDb, vault, query, {
+        limit: limit ?? 5,
+        folder,
+        tag,
+        after,
+        before,
+      });
       const anchorIds = [...new Set(chunks.map((c) => c.noteId))];
       const { neighbors, truncated } =
         anchorIds.length > 0

--- a/test/retrieval/baseline.json
+++ b/test/retrieval/baseline.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-19T20:47:23.673Z",
-  "queryCount": 20,
+  "generatedAt": "2026-04-19T21:13:57.179Z",
+  "queryCount": 23,
   "summary": {
     "keyword": {
       "overall": {
@@ -33,14 +33,19 @@
           "recallAt5": 0,
           "mrrAt5": 0,
           "count": 4
+        },
+        "filter-scope": {
+          "recallAt5": 0,
+          "mrrAt5": 0,
+          "count": 0
         }
       }
     },
     "semantic": {
       "overall": {
         "recallAt5": 1,
-        "mrrAt5": 0.885,
-        "count": 20
+        "mrrAt5": 0.9,
+        "count": 23
       },
       "byCategory": {
         "keyword-only": {
@@ -67,14 +72,19 @@
           "recallAt5": 1,
           "mrrAt5": 0.875,
           "count": 4
+        },
+        "filter-scope": {
+          "recallAt5": 1,
+          "mrrAt5": 1,
+          "count": 3
         }
       }
     },
     "chunks": {
       "overall": {
-        "recallAt5": 0.85,
-        "mrrAt5": 0.8,
-        "count": 20
+        "recallAt5": 0.8696,
+        "mrrAt5": 0.8261,
+        "count": 23
       },
       "byCategory": {
         "keyword-only": {
@@ -101,6 +111,11 @@
           "recallAt5": 0.5,
           "mrrAt5": 0.5,
           "count": 4
+        },
+        "filter-scope": {
+          "recallAt5": 1,
+          "mrrAt5": 1,
+          "count": 3
         }
       }
     }

--- a/test/retrieval/eval.js
+++ b/test/retrieval/eval.js
@@ -78,11 +78,12 @@ function chunkRankMatching(results, expectedNoteId, expectedChunkHeading) {
 }
 
 function aggregate(perQuery) {
-  const total = perQuery.length;
+  const scored = perQuery.filter((q) => !q.skipped);
+  const total = scored.length;
   if (total === 0) return { recallAt5: 0, mrrAt5: 0, count: 0 };
   let hits = 0;
   let mrrSum = 0;
-  for (const q of perQuery) {
+  for (const q of scored) {
     if (q.rank !== null) {
       hits++;
       mrrSum += 1 / q.rank;
@@ -142,19 +143,27 @@ async function runEval(opts) {
       category: q.category ?? "uncategorized",
     };
 
-    const kwResults = vault.search(q.query).slice(0, K);
-    perTool.keyword.push({
-      ...baseEntry,
-      rank: rankOfNote(kwResults, q.expectedNoteId, "id"),
-    });
+    const searchOpts = { limit: K, ...(q.filters ?? {}) };
 
-    const semResults = await semanticSearch(db, vault, q.query, K);
+    // Keyword tool is note-level and doesn't support filters; when a query
+    // specifies filters we skip keyword so we don't mis-attribute misses.
+    if (q.filters) {
+      perTool.keyword.push({ ...baseEntry, rank: null, skipped: true });
+    } else {
+      const kwResults = vault.search(q.query).slice(0, K);
+      perTool.keyword.push({
+        ...baseEntry,
+        rank: rankOfNote(kwResults, q.expectedNoteId, "id"),
+      });
+    }
+
+    const semResults = await semanticSearch(db, vault, q.query, searchOpts);
     perTool.semantic.push({
       ...baseEntry,
       rank: rankOfNote(semResults, q.expectedNoteId, "id"),
     });
 
-    const chunkResults = await searchChunks(db, vault, q.query, K);
+    const chunkResults = await searchChunks(db, vault, q.query, searchOpts);
     perTool.chunks.push({
       ...baseEntry,
       rank: chunkRankMatching(

--- a/test/retrieval/gold.json
+++ b/test/retrieval/gold.json
@@ -104,6 +104,24 @@
       "expectedNoteId": "tempo/overview",
       "expectedChunkHeading": "Stack",
       "category": "multi-section"
+    },
+    {
+      "query": "architecture",
+      "filters": { "folder": "tempo/designs" },
+      "expectedNoteId": "tempo/designs/frontend-architecture",
+      "category": "filter-scope"
+    },
+    {
+      "query": "what did we decide about backgrounded timers",
+      "filters": { "tag": "adr" },
+      "expectedNoteId": "tempo/adrs/adr-002-web-workers-for-timers",
+      "category": "filter-scope"
+    },
+    {
+      "query": "list of things that bit us in production",
+      "filters": { "tag": ["gotchas", "adr"] },
+      "expectedNoteId": "tempo/gotchas/gotchas",
+      "category": "filter-scope"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a true pre-filter to sqlite-vec chunk search: `searchChunks` / `semanticSearch` now accept `{ limit, folder, tag, after, before }` so results are ranked *inside* the filtered subset (not post-K truncation).
- Schema: new `tags_json` + `note_date` columns on `note_chunks`, plus cache filename bump (`embeddings.db` → `embeddings-v2.db`) so existing caches rebuild cleanly.
- Surfaced via MCP (`vault_semantic_search`, `vault_search_chunks`, `vault_search_chunks_with_context`) and matching CLI flags (`--folder`, `--tag`, `--after`, `--before`).
- Eval harness threads `q.filters` into the tool under test and skips keyword for filter-only fixtures (note-level keyword search can't honor filters). 3 new `filter-scope` fixtures added to gold; baseline refreshed.

## Why
Issue #17 — Phase 1 retrieval precision. Without pre-filter, asking "find X in folder Y" would nominally re-rank post-hoc and lose chunks if the top-K globally didn't include any Y. Now filters are rowid-joined before vec search so `limit` counts only candidates in-scope.

## Baseline (23 queries)
| tool     | recall@5 | MRR@5 |
|----------|----------|-------|
| keyword  | 20.0%    | 0.200 |
| semantic | 100.0%   | 0.900 |
| chunks   | 87.0%    | 0.826 |

filter-scope category: semantic 100% / chunks 100%.

## Test plan
- [x] `node test/retrieval/eval.js` passes, no regression vs prior baseline
- [x] CLI smoke: `semantic-search "architecture" --folder tempo/designs --limit 2` narrows to the 1 note in that folder
- [x] CLI smoke: `search-chunks "timers" --tag adr --limit 3` returns only adr-tagged chunks
- [x] `npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js` clean
- [ ] CI green on Node 20 + 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)