### PR TITLE
feat(hyde): remote HyDE query expansion, opt-in (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ Full roadmap tracker: **[#33 — LLM-first documentation](https://github.com/ber
 
 Infra-only changes that improve what agents get back from a query. No content migration required.
 
-- [ ] **[Retrieval eval harness](https://github.com/bernabranco/claude-code-vault/issues/15)** — gold query→passage dataset + recall@k regression test. *Prerequisite for everything else in Phase 1.*
+- [x] **[Retrieval eval harness](https://github.com/bernabranco/claude-code-vault/issues/15)** — gold query→passage dataset + recall@k regression test. *Prerequisite for everything else in Phase 1.*
 - [ ] **[Hybrid search](https://github.com/bernabranco/claude-code-vault/issues/4)** — fuse keyword + semantic scores via RRF
 - [ ] **[Reranker](https://github.com/bernabranco/claude-code-vault/issues/5)** — cross-encoder pass over top-K for precision
-- [ ] **[HyDE query expansion](https://github.com/bernabranco/claude-code-vault/issues/16)** — embed a hypothetical answer instead of the raw query
-- [ ] **[Filter-before-rank](https://github.com/bernabranco/claude-code-vault/issues/17)** — scope semantic search by tag / folder / date / type
+- [x] **[HyDE query expansion](https://github.com/bernabranco/claude-code-vault/issues/16)** — embed a hypothetical answer instead of the raw query. See [docs/hyde.md](docs/hyde.md).
+- [x] **[Filter-before-rank](https://github.com/bernabranco/claude-code-vault/issues/17)** — scope semantic search by tag / folder / date / type
 
 ### Phase 2 — Provenance + content quality
 
@@ -228,7 +228,7 @@ Polish after the core is solid.
 
 ## Evaluation
 
-Retrieval changes (semantic search, chunk search, future HyDE/filter work) are gated by an eval harness — `test/retrieval/eval.js` — that runs a hand-authored gold dataset through every search tool and reports `recall@5` and `MRR@5`. CI fails if a tool's recall@5 drops by more than **5pp** vs the committed baseline.
+Retrieval changes (semantic search, chunk search, HyDE, filters) are gated by an eval harness — `test/retrieval/eval.js` — that runs a hand-authored gold dataset through every search tool and reports `recall@5` and `MRR@5`. CI fails if a tool's recall@5 drops by more than **5pp** vs the committed baseline.
 
 ```bash
 # Run the harness against the current code
@@ -240,11 +240,16 @@ node test/retrieval/eval.js --update-baseline
 # Tighten the regression gate
 node test/retrieval/eval.js --gate 2
 
+# Measure HyDE lift (needs ANTHROPIC_API_KEY; falls back to raw query without)
+node test/retrieval/eval.js --hyde
+
 # Machine-readable output
 node test/retrieval/eval.js --json
 ```
 
-The dataset (`test/retrieval/gold.json`) is hand-authored and tagged by category (`keyword-only`, `semantic-only`, `vocabulary-gap`, `graph-context`, `multi-section`) so a regression in one category is visible even when the overall number looks fine. Add new entries when shipping a note whose retrieval is non-obvious; never delete entries to make a metric look better.
+The dataset (`test/retrieval/gold.json`) is hand-authored and tagged by category (`keyword-only`, `semantic-only`, `vocabulary-gap`, `graph-context`, `multi-section`, `filter-scope`) so a regression in one category is visible even when the overall number looks fine. Add new entries when shipping a note whose retrieval is non-obvious; never delete entries to make a metric look better.
+
+Deep-dives on individual retrieval techniques live under [docs/](docs/) — see [docs/hyde.md](docs/hyde.md) for how query expansion works and when to enable it.
 
 ## Contributing
 

--- a/docs/hyde.md
+++ b/docs/hyde.md
@@ -1,0 +1,122 @@
+# HyDE: Hypothetical Document Embeddings
+
+**Status:** shipped in PR for issue #16 (Phase 1 — retrieval precision).
+
+HyDE is a query-side trick that lifts semantic-search recall on queries whose vocabulary doesn't match the target doc. This is *not* an indexing change — the vault embeddings stay exactly the same. The trick happens at search time.
+
+## The problem
+
+Embedding models (ours is `Xenova/all-MiniLM-L6-v2`, 384-dim) were trained mostly on `(passage, paraphrase of passage)` pairs. Their vector space is good at placing similar-looking *text* near each other. It is **not** optimized for the `(short question, long answer)` gap.
+
+So this happens:
+
+- User types: `"why did we pick local DB"`
+- Target ADR says: `"SQLite-WASM persisted to OPFS... round-trip to a remote server introduced 1–3s latencies... broke the 'start in one click' promise"`
+
+None of the target's words appear in the query. The model has to bridge `"local DB"` ↔ `"SQLite-WASM / OPFS / no network round-trip"` through pure semantic generalization. On a small, tight vault it usually works. On a bigger, messier corpus, recall drops.
+
+## How HyDE bridges the gap
+
+At search time, before embedding the query, ask a fast LLM to write a fake passage that would answer it:
+
+```
+Prompt: Write a 2-3 sentence passage from an engineering document that would
+        answer this question: "why did we pick local DB"
+
+LLM:    We chose local-first storage using an embedded database because round-trips
+        to a remote server introduced unacceptable latency on session start.
+        SQLite running in the browser via WASM lets us persist user data without
+        any network dependency.
+```
+
+That fake passage **is never indexed** — it's only used as a search probe. We embed `"${query}\n\n${hypoPassage}"` and query sqlite-vec with that vector. The hypothetical passage shares vocabulary with real docs (`"latency"`, `"round-trip"`, `"SQLite"`, `"WASM"`, `"local-first"`), so cosine similarity with the real chunks climbs.
+
+The original paper: [Gao et al., 2022 — Precise Zero-Shot Dense Retrieval without Relevance Labels](https://arxiv.org/abs/2212.10496).
+
+## Concrete gains
+
+On the tempo vault, our `vocabulary-gap` category (see [test/retrieval/gold.json](../test/retrieval/gold.json)) already hits 100% recall@5 for semantic — there's no headroom to demonstrate HyDE lift on this specific corpus. The value shows up on larger, lower-precision corpora where:
+
+1. The query uses generic words (`"how do we handle auth"`)
+2. The target docs use proprietary/jargon vocabulary (`"Identity Broker middleware"`, `"JWT rotation cadence"`)
+
+We've wired HyDE so you can enable it per-query and measure on your own vault.
+
+## Usage
+
+### Prerequisites
+
+Set `ANTHROPIC_API_KEY` in your environment. Never commit it:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."   # shell profile, or .env (gitignored)
+```
+
+No key? HyDE logs a single warning and falls back to the raw query. It is *never* a hard failure.
+
+### CLI
+
+```bash
+# Add --hyde to any of the three semantic commands
+claude-code-vault semantic-search "why did we pick local DB" --hyde
+claude-code-vault search-chunks "timer accuracy in background tabs" --hyde
+claude-code-vault search-with-context "storage tradeoffs" --hyde
+```
+
+### MCP
+
+Add `"hyde": true` to the tool-call args:
+
+```json
+{
+  "name": "vault_semantic_search",
+  "arguments": {
+    "query": "why did we pick local DB",
+    "hyde": true
+  }
+}
+```
+
+All three semantic tools accept it: `vault_semantic_search`, `vault_search_chunks`, `vault_search_chunks_with_context`.
+
+### Eval harness
+
+```bash
+node test/retrieval/eval.js --hyde              # measure + diff vs baseline
+node test/retrieval/eval.js --hyde --update-baseline
+```
+
+## Design decisions
+
+**Concat, not replace.** We embed `${query}\n\n${passage}` rather than the passage alone. If the LLM hallucinates vocabulary that drifts away from your corpus, keeping the raw query in the embedding text anchors the search. This is a known robust variant of the original HyDE.
+
+**Haiku, not Opus/Sonnet.** HyDE only needs vocabulary overlap — not factual accuracy or deep reasoning. Haiku is ~10× cheaper and ~3× faster. Model is pinned in [`lib/hyde.js`](../lib/hyde.js) (`HYDE_MODEL`) if you want to change it.
+
+**Opt-in, not always-on.** Every HyDE query adds one LLM round-trip (~300ms, ~$0.001). That's fine for chat use but wrong for bulk indexing or fully-local operation. Users toggle it per-query via the `--hyde` flag / `hyde: true` arg.
+
+**Graceful fallback.** Missing API key, network error, or API failure → log once, use the raw query, search proceeds normally. HyDE is an upgrade, never a dependency.
+
+**Remote-only (for now).** The Phase 1 roadmap scoped HyDE to the Anthropic API. A fully-local variant (small local model generating the hypothetical) is a future consideration — likely via `@huggingface/transformers` with a small instruction-tuned model, but generation quality matters less than for chat so it's tractable.
+
+## When HyDE does *not* help
+
+- **Keyword-shaped queries** (`"ADR-001"`, `"pricing"`, `"gotchas"`) — the raw query already matches title/tag/id. HyDE just adds latency.
+- **Very small vaults** — semantic already works. Measure before enabling.
+- **Queries where the LLM hallucinates wrong jargon** — if the hypothetical passage invents vocabulary that doesn't appear in your corpus, the probe drifts *away* from relevant chunks. Rare with a well-tuned prompt, but possible.
+
+A future optimization: classify the query first (keyword-shaped? vocabulary-gap? multi-hop?) and only invoke HyDE on queries that look like they need it.
+
+## Security
+
+- Keys live in `process.env.ANTHROPIC_API_KEY` only — never hardcoded.
+- `.env` and `.env.local` are in `.gitignore`.
+- HyDE logs never include the key value.
+- The query is sent to the Anthropic API when HyDE is on — treat query text the same way you treat any other outbound LLM call.
+
+## Files touched
+
+- [lib/hyde.js](../lib/hyde.js) — the `expandWithHyde(query)` helper
+- [lib/embeddings.js](../lib/embeddings.js) — `searchChunks` reads `opts.hyde` and enriches the query before `embedText`
+- [lib/mcp.js](../lib/mcp.js) — `hyde: z.boolean().optional()` on the three semantic tools
+- [index.js](../index.js) — `--hyde` CLI flag on the three semantic commands
+- [test/retrieval/eval.js](../test/retrieval/eval.js) — `--hyde` flag for measuring lift vs baseline

--- a/index.js
+++ b/index.js
@@ -526,6 +526,7 @@ program
   .option("--tag <tag...>", "Restrict to notes with any of these tags")
   .option("--after <date>", "Restrict to notes with frontmatter date >= YYYY-MM-DD")
   .option("--before <date>", "Restrict to notes with frontmatter date <= YYYY-MM-DD")
+  .option("--hyde", "Expand query with a hypothetical answer (needs ANTHROPIC_API_KEY)")
   .option("--json", "Output as JSON")
   .description("Search vault by meaning (note-level, local embeddings)")
   .action(async (query, options) => {
@@ -537,6 +538,7 @@ program
       tag: options.tag,
       after: options.after,
       before: options.before,
+      hyde: options.hyde,
     });
     db.close();
 
@@ -558,6 +560,7 @@ program
   .option("--tag <tag...>", "Restrict to notes with any of these tags")
   .option("--after <date>", "Restrict to notes with frontmatter date >= YYYY-MM-DD")
   .option("--before <date>", "Restrict to notes with frontmatter date <= YYYY-MM-DD")
+  .option("--hyde", "Expand query with a hypothetical answer (needs ANTHROPIC_API_KEY)")
   .option("--json", "Output as JSON")
   .description("Search vault at paragraph/section level (chunk retrieval)")
   .action(async (query, options) => {
@@ -569,6 +572,7 @@ program
       tag: options.tag,
       after: options.after,
       before: options.before,
+      hyde: options.hyde,
     });
     db.close();
 
@@ -658,6 +662,7 @@ program
   .option("--tag <tag...>", "Restrict to notes with any of these tags")
   .option("--after <date>", "Restrict to notes with frontmatter date >= YYYY-MM-DD")
   .option("--before <date>", "Restrict to notes with frontmatter date <= YYYY-MM-DD")
+  .option("--hyde", "Expand query with a hypothetical answer (needs ANTHROPIC_API_KEY)")
   .option("--json", "Output as JSON")
   .description("Search chunks and include graph neighbors of hit notes")
   .action(async (query, options) => {
@@ -670,6 +675,7 @@ program
       tag: options.tag,
       after: options.after,
       before: options.before,
+      hyde: options.hyde,
     });
     const anchorIds = [...new Set(chunks.map((c) => c.noteId))];
     const { neighbors, truncated } =

--- a/lib/embeddings.js
+++ b/lib/embeddings.js
@@ -4,6 +4,7 @@ import { pipeline } from "@huggingface/transformers";
 import fs from "fs/promises";
 import path from "path";
 import { chunkMarkdown } from "./chunks.js";
+import { expandWithHyde } from "./hyde.js";
 
 const EMBED_MODEL = "Xenova/all-MiniLM-L6-v2";
 const EMBED_DIMS = 384;
@@ -191,7 +192,14 @@ function normalizeOpts(optsOrLimit, defaultLimit) {
 
 export async function searchChunks(db, vault, query, optsOrLimit) {
   const opts = normalizeOpts(optsOrLimit, 5);
-  const queryVec = await embedText(query);
+  const effectiveQuery = opts.hyde
+    ? await expandWithHyde(query, {
+        apiKey: opts.apiKey,
+        model: opts.hydeModel,
+        warnIfNoKey: opts.warnIfNoHydeKey,
+      })
+    : query;
+  const queryVec = await embedText(effectiveQuery);
   const filter = buildFilterClause(opts);
   const sql = `
     SELECT c.note_id, c.chunk_idx, c.heading_path, c.text, c.links, v.distance

--- a/lib/hyde.js
+++ b/lib/hyde.js
@@ -1,0 +1,75 @@
+/**
+ * HyDE (Hypothetical Document Embeddings) query expansion.
+ *
+ * At search time, ask an LLM to write a short passage that would answer the
+ * user's query, then embed `${query}\n\n${passage}` instead of the raw query.
+ * The hypothetical passage uses the same concrete vocabulary as real docs, so
+ * cosine similarity with chunks climbs on vocabulary-gap queries (short
+ * interrogative query vs. long declarative doc).
+ *
+ * Remote-only by design — requires ANTHROPIC_API_KEY. Falls back to the raw
+ * query on missing key or API error, so enabling HyDE is never a hard failure.
+ */
+
+const HYDE_MODEL = "claude-haiku-4-5-20251001";
+const HYDE_MAX_TOKENS = 200;
+const HYDE_ENDPOINT = "https://api.anthropic.com/v1/messages";
+
+const HYDE_SYSTEM =
+  "You generate brief, concrete passages that sound like they came from engineering documentation. You use specific technical vocabulary (library names, protocol names, concrete verbs) rather than hedged or abstract language. You never preface or explain — you only emit the passage.";
+
+const HYDE_USER = (query) =>
+  `Write a 2-3 sentence passage from an engineering document that would answer this question:\n\n${query}\n\nReturn only the passage. No preamble, no quotes, no headings.`;
+
+/**
+ * Return either `${query}\n\n${hypoDoc}` (on success) or the raw query (on
+ * missing key / API error). Never throws — callers can treat this as a
+ * transparent upgrade.
+ */
+export async function expandWithHyde(query, opts = {}) {
+  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    if (opts.warnIfNoKey !== false) {
+      console.error(
+        "[hyde] ANTHROPIC_API_KEY not set — falling back to raw query"
+      );
+    }
+    return query;
+  }
+
+  try {
+    const res = await fetch(HYDE_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: opts.model ?? HYDE_MODEL,
+        max_tokens: HYDE_MAX_TOKENS,
+        system: HYDE_SYSTEM,
+        messages: [{ role: "user", content: HYDE_USER(query) }],
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error(
+        `[hyde] API ${res.status} — falling back to raw query${
+          body ? ` (${body.slice(0, 200)})` : ""
+        }`
+      );
+      return query;
+    }
+
+    const data = await res.json();
+    const passage = data?.content?.[0]?.text?.trim();
+    if (!passage) return query;
+
+    return `${query}\n\n${passage}`;
+  } catch (err) {
+    console.error(`[hyde] ${err.message} — falling back to raw query`);
+    return query;
+  }
+}

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -182,9 +182,10 @@ if (embeddingsDb) {
         tag: z.union([z.string(), z.array(z.string())]).optional(),
         after: z.string().optional(),
         before: z.string().optional(),
+        hyde: z.boolean().optional(),
       },
     },
-    safe(async ({ query, limit, folder, tag, after, before }) => {
+    safe(async ({ query, limit, folder, tag, after, before, hyde }) => {
       await embeddingsReady;
       if (!embeddingsDb) {
         return {
@@ -198,6 +199,7 @@ if (embeddingsDb) {
         tag,
         after,
         before,
+        hyde,
       });
       return {
         content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -217,9 +219,10 @@ if (embeddingsDb) {
         tag: z.union([z.string(), z.array(z.string())]).optional(),
         after: z.string().optional(),
         before: z.string().optional(),
+        hyde: z.boolean().optional(),
       },
     },
-    safe(async ({ query, limit, folder, tag, after, before }) => {
+    safe(async ({ query, limit, folder, tag, after, before, hyde }) => {
       await embeddingsReady;
       if (!embeddingsDb) {
         return {
@@ -233,6 +236,7 @@ if (embeddingsDb) {
         tag,
         after,
         before,
+        hyde,
       });
       return {
         content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -304,9 +308,10 @@ if (embeddingsDb) {
         tag: z.union([z.string(), z.array(z.string())]).optional(),
         after: z.string().optional(),
         before: z.string().optional(),
+        hyde: z.boolean().optional(),
       },
     },
-    safe(async ({ query, limit, depth, maxChars, folder, tag, after, before }) => {
+    safe(async ({ query, limit, depth, maxChars, folder, tag, after, before, hyde }) => {
       await embeddingsReady;
       if (!embeddingsDb) {
         return {
@@ -320,6 +325,7 @@ if (embeddingsDb) {
         tag,
         after,
         before,
+        hyde,
       });
       const anchorIds = [...new Set(chunks.map((c) => c.noteId))];
       const { neighbors, truncated } =

--- a/test/retrieval/eval.js
+++ b/test/retrieval/eval.js
@@ -34,6 +34,7 @@ function parseArgs(argv) {
     updateBaseline: false,
     gate: 5,
     json: false,
+    hyde: false,
     vault: path.resolve(__dirname, "..", "..", "vault"),
     gold: path.join(__dirname, "gold.json"),
     baseline: path.join(__dirname, "baseline.json"),
@@ -42,13 +43,14 @@ function parseArgs(argv) {
     const a = argv[i];
     if (a === "--update-baseline") args.updateBaseline = true;
     else if (a === "--json") args.json = true;
+    else if (a === "--hyde") args.hyde = true;
     else if (a === "--gate") args.gate = Number(argv[++i]);
     else if (a === "--vault") args.vault = path.resolve(argv[++i]);
     else if (a === "--gold") args.gold = path.resolve(argv[++i]);
     else if (a === "--baseline") args.baseline = path.resolve(argv[++i]);
     else if (a === "--help" || a === "-h") {
       console.log(
-        "Usage: node test/retrieval/eval.js [--update-baseline] [--gate N] [--json] [--vault DIR] [--gold FILE] [--baseline FILE]",
+        "Usage: node test/retrieval/eval.js [--update-baseline] [--gate N] [--json] [--hyde] [--vault DIR] [--gold FILE] [--baseline FILE]",
       );
       process.exit(0);
     } else {
@@ -125,6 +127,12 @@ async function runEval(opts) {
     process.stderr.write(
       `[eval] vault=${opts.vault} notes=${vault.index.length} queries=${queries.length}\n`,
     );
+    if (opts.hyde) {
+      const hasKey = Boolean(process.env.ANTHROPIC_API_KEY);
+      process.stderr.write(
+        `[eval] HyDE enabled${hasKey ? "" : " — no ANTHROPIC_API_KEY, falling back to raw queries"}\n`,
+      );
+    }
     process.stderr.write(`[eval] embedding chunks (one-time)...\n`);
   }
   await syncEmbeddings(db, vault);
@@ -143,7 +151,12 @@ async function runEval(opts) {
       category: q.category ?? "uncategorized",
     };
 
-    const searchOpts = { limit: K, ...(q.filters ?? {}) };
+    const searchOpts = {
+      limit: K,
+      ...(q.filters ?? {}),
+      hyde: opts.hyde,
+      warnIfNoHydeKey: false,
+    };
 
     // Keyword tool is note-level and doesn't support filters; when a query
     // specifies filters we skip keyword so we don't mis-attribute misses.


### PR DESCRIPTION
## Summary
- Adds a query-side expansion step: when `hyde: true` / `--hyde` is set, we ask the Anthropic API (Haiku 4.5) for a 2-3 sentence hypothetical passage that would answer the query, then embed `\${query}\n\n\${passage}` and search with that. The hypothetical shares vocabulary with real docs, so cosine similarity lifts on vocabulary-gap queries.
- Remote-only, opt-in, graceful fallback. No key, network error, or API error → log once and use the raw query. HyDE is never a hard failure.
- Concat (not replace) so a hallucinated passage can't fully drift the search away from the raw query anchor.
- New deep-dive doc: [docs/hyde.md](docs/hyde.md) with worked examples from the tempo vault, trade-offs (why Haiku, why concat, why opt-in, when HyDE does NOT help), and usage for CLI / MCP / eval.

## Why
Phase 1, issue #16. Semantic search alone relies on the embedding model bridging short interrogative queries to long declarative docs, which it wasn't specifically trained for. HyDE sidesteps that by making the probe *look like* a doc. Pays off on corpora where queries use generic words and targets use proprietary jargon.

## Surfaces
- **CLI:** \`--hyde\` on \`semantic-search\`, \`search-chunks\`, \`search-with-context\`
- **MCP:** \`hyde: boolean\` on \`vault_semantic_search\`, \`vault_search_chunks\`, \`vault_search_chunks_with_context\`
- **Eval:** \`node test/retrieval/eval.js --hyde\` — emits one info line at start if no key, then measures lift (or no-op fallback) across all gold queries

## Security
- Key reads from \`process.env.ANTHROPIC_API_KEY\` only. Never hardcoded, never logged.
- \`.env\` / \`.env.local\` remain gitignored.
- docs/hyde.md uses the placeholder \`sk-ant-...\` (literal ellipsis), not a real key.

## Test plan
- [x] \`node test/retrieval/eval.js\` — no regression vs prior baseline (chunks 87% / semantic 100%)
- [x] \`node test/retrieval/eval.js --hyde\` with no key — logs \"HyDE enabled — no ANTHROPIC_API_KEY, falling back to raw queries\" once, then runs exactly like baseline
- [x] CLI smoke: \`semantic-search \"why did we pick local DB\" --hyde\` (no key) → falls back and returns correct hit
- [x] \`npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js\` clean
- [ ] CI green on Node 20 + 22
- [ ] (Manual) Real API key smoke: measure vocabulary-gap lift on a larger vault (out of scope for this PR — tempo already saturates at 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)