### PR TITLE
docs: add GitHub issue and PR templates (closes #6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+## What happened
+
+<!-- A one-line summary of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected vs. actual
+
+**Expected:**
+**Actual:**
+
+## Environment
+
+- `claude-code-vault` version: <!-- `npx claude-code-vault --help` or the version you installed -->
+- Node version: <!-- `node --version` -->
+- OS:
+- Surface: <!-- MCP server / CLI / web viewer / indexer -->
+- Command used: <!-- e.g. `claude-code-vault semantic-search "..." --tag adr` -->
+
+## Extra context
+
+<!-- Paste the relevant part of your vault layout or a minimal reproduction if
+you can share it. If the failure looks indexer-related, try wiping `.vault-cache/`
+and re-running — and mention whether that changes anything. Logs, stack traces,
+screenshots of the viewer — anything that helps. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest a new retrieval technique, MCP tool, CLI command, or viewer capability
+labels: enhancement
+---
+
+## What's the problem
+
+<!-- What are you trying to retrieve / do / see that claude-code-vault can't today? -->
+
+## Proposed shape
+
+<!-- Rough idea of how this would look — a new MCP tool, a new CLI flag,
+a new filter, a viewer affordance. Skip if you're not sure. -->
+
+## Why it belongs here
+
+<!-- claude-code-vault is intentionally narrow: local-first RAG over a
+markdown vault. Embeddings run on-device, the MCP tool surface is small
+and stable, and the database is a cache — the markdown is the source of
+truth. If your idea needs a hosted service, a new model runtime, or
+would grow the tool surface significantly, say so — we'll discuss. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What does this change, and why? One or two sentences. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New retrieval technique / MCP tool / CLI command
+- [ ] Viewer change
+- [ ] Indexer / embeddings change
+- [ ] Docs / chore
+
+## Checks
+
+- [ ] `npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js` passes
+- [ ] `cd web && npx tsc --noEmit` passes (if viewer touched)
+- [ ] Smoke-tested the affected surface (`node lib/mcp.js`, `node index.js ...`, or viewer boot)
+- [ ] `node test/retrieval/eval.js` still green (if retrieval behavior touched)
+- [ ] Updated `README.md` if behavior or flags changed
+- [ ] No new runtime dependencies added to the published tarball (or: listed them below with justification)
+
+## Notes
+
+<!-- Anything the reviewer should know — tradeoffs, follow-ups, screenshots
+for viewer changes, recall@5 deltas for retrieval changes, etc. -->


### PR DESCRIPTION
## Summary
Adds `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md`, and `.github/pull_request_template.md` — shape adapted from claude-atlas, prompts tailored to claude-code-vault's surfaces (MCP / CLI / viewer / indexer).

## Changes
- `.github/ISSUE_TEMPLATE/bug_report.md` — prompts for version, Node, OS, surface, command used, and a hint to try wiping `.vault-cache/` for indexer-related failures.
- `.github/ISSUE_TEMPLATE/feature_request.md` — frames the scope (local-first RAG, small stable MCP surface, markdown is source of truth) so scope-expanding requests get discussed up front.
- `.github/pull_request_template.md` — checks match what CONTRIBUTING.md already describes: typecheck, viewer typecheck if touched, surface smoke, `node test/retrieval/eval.js` for retrieval changes, no new runtime tarball deps.

## Verification
- [x] Files render correctly (valid frontmatter, no markdown errors)
- [x] Match the format CONTRIBUTING.md describes
- [x] Should bump GitHub Community Standards from 4/6 to 6/6

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)