### PR TITLE
feat: extend frontmatter schema with status/type/summary/lastVerified (closes #18)

### DIFF
--- a/lib/embeddings.js
+++ b/lib/embeddings.js
@@ -251,6 +251,10 @@ export async function semanticSearch(db, vault, query, optsOrLimit) {
       id: hit.noteId,
       title: hit.title,
       tags: note?.tags ?? [],
+      status: note?.status,
+      type: note?.type,
+      summary: note?.summary,
+      lastVerified: note?.lastVerified,
       similarity: hit.similarity,
       bestChunkHeading: hit.headingPath.join(" > "),
     };

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -81,12 +81,16 @@ server.registerTool(
     const results = vault
       .search(query)
       .slice(0, limit ?? 10)
-      .map(({ id, title, tags, relevance, wordCount }) => ({
+      .map(({ id, title, tags, relevance, wordCount, status, type, summary, lastVerified }) => ({
         id,
         title,
         tags,
         relevance,
         wordCount,
+        status,
+        type,
+        summary,
+        lastVerified,
       }));
     return {
       content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
@@ -114,6 +118,10 @@ server.registerTool(
       id: note.id,
       title: note.title,
       tags: note.tags,
+      status: note.status,
+      type: note.type,
+      summary: note.summary,
+      lastVerified: note.lastVerified,
       content: note.content,
       links: note.links,
       backlinks,
@@ -132,11 +140,15 @@ server.registerTool(
     inputSchema: { tag: z.string().optional() },
   },
   safe(async ({ tag }) => {
-    const notes = vault.list(tag).map(({ id, title, tags, wordCount }) => ({
+    const notes = vault.list(tag).map(({ id, title, tags, wordCount, status, type, summary, lastVerified }) => ({
       id,
       title,
       tags,
       wordCount,
+      status,
+      type,
+      summary,
+      lastVerified,
     }));
     return {
       content: [{ type: "text", text: JSON.stringify(notes, null, 2) }],
@@ -281,6 +293,10 @@ if (embeddingsDb) {
           id: note.id,
           title: note.title,
           tags: note.tags,
+          status: note.status,
+          type: note.type,
+          summary: note.summary,
+          lastVerified: note.lastVerified,
           content: note.content,
           links: note.links,
           backlinks: vault.getBacklinksFor(id),

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -4,6 +4,26 @@ import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const KNOWN_STATUSES = new Set(["draft", "current", "stale", "deprecated"]);
+const KNOWN_TYPES = new Set([
+  "adr",
+  "feature",
+  "gotcha",
+  "runbook",
+  "glossary",
+  "overview",
+  "architecture",
+  "research",
+]);
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const warnedFor = new Set();
+function warnOnce(filePath, field, value) {
+  const key = `${filePath}::${field}::${value}`;
+  if (warnedFor.has(key)) return;
+  warnedFor.add(key);
+  console.error(`[vault] ${filePath}: unknown ${field} "${value}"`);
+}
+
 /**
  * Vault — indexes and searches markdown files in a local directory.
  *
@@ -66,8 +86,7 @@ export class Vault {
 
       if (frontmatterMatch) {
         const fm = frontmatterMatch[1];
-        // Simple YAML parser (tags, title, date, etc.)
-        frontmatter = this._parseFrontmatter(fm);
+        frontmatter = this._parseFrontmatter(fm, relativePath);
         bodyStart = frontmatterMatch[0].length;
       }
 
@@ -97,6 +116,10 @@ export class Vault {
         size: content.length,
         wordCount,
         frontmatter,
+        status: frontmatter.status ?? "current",
+        type: frontmatter.type ?? null,
+        summary: frontmatter.summary ?? frontmatter.description ?? null,
+        lastVerified: frontmatter.lastVerified ?? null,
         lastModified: (await fs.stat(filePath)).mtime.toISOString(),
       };
     } catch (err) {
@@ -107,9 +130,10 @@ export class Vault {
 
   /**
    * Simple YAML frontmatter parser.
-   * Extracts title, tags, date, description, etc.
+   * Recognized: title, tags, date, description, status, type, summary, lastVerified.
+   * Unknown enum values for status/type are warned to stderr but kept as-is.
    */
-  _parseFrontmatter(yaml) {
+  _parseFrontmatter(yaml, filePath = "<unknown>") {
     const result = {};
     const lines = yaml.split("\n");
 
@@ -117,20 +141,35 @@ export class Vault {
       const [key, ...valueParts] = line.split(":");
       if (!key || !valueParts.length) continue;
 
+      const k = key.trim();
       const value = valueParts.join(":").trim();
 
-      if (key.trim() === "title") {
+      if (k === "title") {
         result.title = value.replace(/^["']|["']$/g, "");
-      } else if (key.trim() === "tags") {
+      } else if (k === "tags") {
         // tags: [auth, firebase, security]
         const match = value.match(/\[(.*?)\]/);
         result.tags = match
           ? match[1].split(",").map((t) => t.trim())
           : [];
-      } else if (key.trim() === "date") {
+      } else if (k === "date") {
         result.date = value;
-      } else if (key.trim() === "description") {
+      } else if (k === "description") {
         result.description = value.replace(/^["']|["']$/g, "");
+      } else if (k === "summary") {
+        result.summary = value.replace(/^["']|["']$/g, "");
+      } else if (k === "status") {
+        const v = value.replace(/^["']|["']$/g, "");
+        if (v && !KNOWN_STATUSES.has(v)) warnOnce(filePath, "status", v);
+        result.status = v || undefined;
+      } else if (k === "type") {
+        const v = value.replace(/^["']|["']$/g, "");
+        if (v && !KNOWN_TYPES.has(v)) warnOnce(filePath, "type", v);
+        result.type = v || undefined;
+      } else if (k === "lastVerified") {
+        const v = value.replace(/^["']|["']$/g, "");
+        if (v && !ISO_DATE_RE.test(v)) warnOnce(filePath, "lastVerified", v);
+        result.lastVerified = v || undefined;
       }
     }
 
@@ -233,6 +272,10 @@ export class Vault {
         tags: note.tags,
         path: note.path,
         wordCount: note.wordCount,
+        status: note.status,
+        type: note.type,
+        summary: note.summary,
+        lastVerified: note.lastVerified,
         lastModified: note.lastModified,
       })),
     };

--- a/vault/README.md
+++ b/vault/README.md
@@ -46,9 +46,24 @@ Add folders as needed; skip the ones you don't use.
 ## Conventions
 
 - **Every project has a `VAULT_SUMMARY.md`** at its root — this is the index Claude reads first.
-- **Frontmatter on every note** — `title`, `tags`, `date`, `description`.
+- **Frontmatter on every note** — see schema below.
 - **Wiki-links are project-scoped**: `[[claude-code-vault/gotchas/gotchas]]`, not `[[gotchas]]`. Keeps links unambiguous once you add more projects.
 - **Gotchas are first-class** — put non-obvious traps in `gotchas/`, not buried in design docs. They're what Claude needs to surface before suggesting changes.
+
+## Frontmatter schema
+
+All fields are optional except where noted; missing fields fall back to sensible defaults. The parser is additive — older notes keep working.
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `title` | recommended | string | Falls back to first H1, then file id |
+| `tags` | recommended | `[a, b, c]` | Combined with inline `#hashtags` from the body |
+| `date` | optional | `YYYY-MM-DD` | When the note was authored. Used by `after`/`before` filters. |
+| `description` | optional | string | One-line blurb shown in search results / list views |
+| `summary` | optional | string | Longer TL;DR. Falls back to `description` when absent. Future: pinned as chunk-0. |
+| `status` | optional | `draft \| current \| stale \| deprecated` | Defaults to `current`. Drives status-aware retrieval (future). |
+| `type` | optional | `adr \| feature \| gotcha \| runbook \| glossary \| overview \| architecture \| research` | Enables typed-note schemas (future). Unknown values warn on stderr. |
+| `lastVerified` | optional | `YYYY-MM-DD` | Last time the note's claims were checked against reality. Distinct from file mtime. |
 
 ## Example frontmatter
 
@@ -58,6 +73,10 @@ title: My Note Title
 tags: [project-name, adr, storage]
 date: 2026-04-17
 description: One-line summary used in search results and the index
+summary: Longer TL;DR — what this note tells you and when to read it
+status: current
+type: adr
+lastVerified: 2026-04-20
 ---
 
 # Note Content

--- a/vault/claude-code-vault/VAULT_SUMMARY.md
+++ b/vault/claude-code-vault/VAULT_SUMMARY.md
@@ -2,7 +2,10 @@
 id: vault-summary
 title: claude-code-vault — vault summary
 description: Top-level orientation for the claude-code-vault demo vault — what's in here and where to start
-type: summary
+summary: Index and orientation for the claude-code-vault self-docs. Lists every note in this vault and points new readers at the right starting note.
+type: overview
+status: current
+lastVerified: 2026-04-20
 tags: [orientation, index]
 ---
 

--- a/vault/claude-code-vault/adrs/adr-001-local-first-embeddings.md
+++ b/vault/claude-code-vault/adrs/adr-001-local-first-embeddings.md
@@ -2,9 +2,11 @@
 id: adr-001-local-first-embeddings
 title: ADR-001 — local-first embeddings with MiniLM + sqlite-vec
 description: Why claude-code-vault embeds on-device with a small sentence-transformer rather than calling a remote embedding API
+summary: Decision (accepted 2026-03-01) to embed on-device with all-MiniLM-L6-v2 + sqlite-vec rather than call a remote embedding API. Trade-off accepted: 384-dim recall ceiling in exchange for no API key, no network, and no per-query cost.
 type: adr
-status: accepted
+status: current
 date: 2026-03-01
+lastVerified: 2026-04-20
 tags: [decision, embeddings, local-first]
 ---
 

--- a/vault/claude-code-vault/architecture/cli.md
+++ b/vault/claude-code-vault/architecture/cli.md
@@ -2,7 +2,10 @@
 id: cli
 title: CLI architecture
 description: Commands exposed by the claude-code-vault CLI and the conventions they share
+summary: The CLI command surface, the shared filter flags (folder/tag/after/before), and how HyDE is opted in via --hyde.
 type: architecture
+status: current
+lastVerified: 2026-04-20
 tags: [cli, commander]
 ---
 

--- a/vault/claude-code-vault/architecture/embeddings-pipeline.md
+++ b/vault/claude-code-vault/architecture/embeddings-pipeline.md
@@ -2,7 +2,10 @@
 id: embeddings-pipeline
 title: Embeddings pipeline architecture
 description: How notes are chunked, embedded, indexed, and queried with sqlite-vec, including the filter-before-rank pattern
+summary: Chunking, embedding, sqlite-vec schema, and the filter-before-rank rowid pre-filter that scopes vector search by tag/folder/date before ranking.
 type: architecture
+status: current
+lastVerified: 2026-04-20
 tags: [embeddings, sqlite-vec, indexing]
 ---
 

--- a/vault/claude-code-vault/architecture/mcp-server.md
+++ b/vault/claude-code-vault/architecture/mcp-server.md
@@ -2,7 +2,10 @@
 id: mcp-server
 title: MCP server architecture
 description: The stdio MCP server's tool surface, lifecycle, and how it shares the index with the CLI
+summary: How the MCP server boots, what tools it registers, why everything must use stderr (not stdout), and how the in-process index is shared with the CLI.
 type: architecture
+status: current
+lastVerified: 2026-04-20
 tags: [mcp, server, contract]
 ---
 

--- a/vault/claude-code-vault/features/graph-expansion.md
+++ b/vault/claude-code-vault/features/graph-expansion.md
@@ -2,7 +2,10 @@
 id: graph-expansion
 title: Graph expansion via wiki-links
 description: How vault_related and read-with-context walk the wiki-link graph to surface neighboring notes
+summary: The wiki-link graph powers vault_related and read-with-context. Bidirectional edges rank first; depth=2 fans out fast and is rarely worth it.
 type: feature
+status: current
+lastVerified: 2026-04-20
 tags: [graph, wiki-links, related]
 ---
 

--- a/vault/claude-code-vault/features/semantic-search.md
+++ b/vault/claude-code-vault/features/semantic-search.md
@@ -2,7 +2,10 @@
 id: semantic-search
 title: Semantic search
 description: How to call semantic search from the CLI and MCP, common filter recipes, and when to enable HyDE
+summary: Concrete CLI and MCP examples for semantic search, the filter recipes you'll actually reach for, and the rule of thumb for when HyDE is worth its latency.
 type: feature
+status: current
+lastVerified: 2026-04-20
 tags: [search, embeddings, mcp, cli]
 ---
 

--- a/vault/claude-code-vault/gotchas/gotchas.md
+++ b/vault/claude-code-vault/gotchas/gotchas.md
@@ -2,7 +2,10 @@
 id: gotchas
 title: Gotchas
 description: Real failure modes you'll hit when running, installing, or extending claude-code-vault, and the fix for each
-type: gotchas
+summary: Real failure modes — NODE_MODULE_VERSION, sqlite-vec rowid ambiguity, cache filename bumps, MCP stdout discipline, chokidar reindex behavior, ANTHROPIC_API_KEY hygiene, no --no-verify or --squash. Read before shipping.
+type: gotcha
+status: current
+lastVerified: 2026-04-20
 tags: [troubleshooting, install, runtime]
 ---
 

--- a/vault/claude-code-vault/overview.md
+++ b/vault/claude-code-vault/overview.md
@@ -2,7 +2,10 @@
 id: overview
 title: claude-code-vault overview
 description: What claude-code-vault is, the four surfaces it exposes, and how a query flows through the system
+summary: Read first — claude-code-vault is a local-first MCP + CLI for retrieval over a markdown vault. This note covers the four surfaces and the query flow.
 type: overview
+status: current
+lastVerified: 2026-04-20
 tags: [introduction, architecture]
 ---
 

--- a/vault/claude-code-vault/research/roadmap.md
+++ b/vault/claude-code-vault/research/roadmap.md
@@ -2,7 +2,10 @@
 id: roadmap
 title: Roadmap
 description: What's shipped, what's next, and what's deliberately out of scope for claude-code-vault
+summary: Shipped so far (filter-before-rank, heading-aware chunking, HyDE, eval harness), near-term retrieval and ergonomics work, and the deliberate non-goals (not Obsidian, not a vector DB, not a remote service).
 type: research
+status: current
+lastVerified: 2026-04-20
 tags: [roadmap, planning]
 ---
 


### PR DESCRIPTION
## Summary

- Additive frontmatter parser extension in `lib/vault.js`: parses `status`, `type`, `summary`, `lastVerified`. Unknown enum values for `status` / `type` warn on stderr (MCP-stdout-safe) and are kept as-is.
- New fields are surfaced as top-level note properties (with `status` defaulting to `"current"`) and pass through `vault_read`, `vault_read_with_context`, `vault_list`, `vault_search`, and `vault_semantic_search` MCP tools.
- Schema documented in `vault/README.md`. All 10 boilerplate notes backfilled with `summary` + `status: current` + `lastVerified: 2026-04-20`.
- Normalized `type: gotchas` → `gotcha` and ADR-001 `status: accepted` → `status: current` (`status` is a freshness field, distinct from ADR lifecycle).

## Type of change

- [x] Indexer / embeddings change (parser + note shape)
- [x] Docs / chore (vault/README schema section, backfill)

## Checks

- [x] `npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js` passes
- [x] Smoke-tested via `node -e` against the vault: `status` / `type` / `summary` / `lastVerified` surface on notes; warnings fire correctly for bad input
- [x] `node test/retrieval/eval.js` still green — zero recall regression (no retrieval behavior change)
- [x] Updated `README.md` (`vault/README.md` schema section)
- [x] No new runtime dependencies

## Notes

Scope is intentionally schema + parsing + MCP surface only. Pinned-chunk indexing for `summary` (so it's always retrievable as `chunk_idx = 0`) is deferred — that's a retrieval-behavior change that fits more naturally with #21 (status-aware retrieval) and would require a cache filename bump.

The `type` enum was widened from the issue's original list to include `architecture` and `research`, which the boilerplate already uses. Linter (#19) will own enforcement.

Unblocks #19 (linter), #20 (typed-note schemas), #21 (status-aware retrieval).