### PR TITLE
feat: vault content linter with text/JSON/GitHub Actions output (closes #19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           node index.js index
           node index.js search "architecture" --limit 3
 
+      - name: Vault lint (errors fail CI, warnings/info annotate PR)
+        run: node index.js lint --format github
+
       - name: Retrieval eval (recall@5 vs baseline)
         run: node test/retrieval/eval.js --gate 5
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,10 @@ cd web && npx tsc --noEmit && cd ..
 npm run build
 node index.js index
 node index.js search "architecture" --limit 3
+node index.js lint
 ```
 
-If those all pass locally, CI should pass too.
+If those all pass locally, CI should pass too. `lint` exits 1 on any `error`-level finding (dead wiki-links, missing `title`).
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Infra-only changes that improve what agents get back from a query. No content mi
 
 Frontmatter additions + linter so agents can trust what they read.
 
-- [ ] **[Frontmatter schema extension](https://github.com/bernabranco/claude-code-vault/issues/18)** — `status`, `lastVerified`, `summary`, `type`
-- [ ] **[Vault content linter](https://github.com/bernabranco/claude-code-vault/issues/19)** — dead links, missing frontmatter, orphans, heading hierarchy, duplicate candidates
+- [x] **[Frontmatter schema extension](https://github.com/bernabranco/claude-code-vault/issues/18)** — `status`, `lastVerified`, `summary`, `type`
+- [x] **[Vault content linter](https://github.com/bernabranco/claude-code-vault/issues/19)** — `claude-code-vault lint` (text/JSON/GitHub formats). Dead links, missing frontmatter, orphans, heading skips, oversize/undersize, duplicate candidates, stale dates, unknown enums. Also exposed as the `vault_lint` MCP tool.
 - [ ] **[Typed-note schemas](https://github.com/bernabranco/claude-code-vault/issues/20)** — ADR / feature / gotcha / runbook / glossary with required fields
 - [ ] **[Status-aware retrieval](https://github.com/bernabranco/claude-code-vault/issues/21)** — downrank stale, exclude deprecated by default
 

--- a/index.js
+++ b/index.js
@@ -240,41 +240,38 @@ program
     }
   });
 
-// ===== CHECK =====
+// ===== LINT =====
 program
-  .command("check")
-  .description("Validate vault: broken links, missing frontmatter")
-  .action(async () => {
+  .command("lint")
+  .description(
+    "Lint vault: dead links, missing frontmatter, orphans, heading skips, stale dates, duplicate candidates"
+  )
+  .option("--format <fmt>", "Output format: text | json | github", "text")
+  .option("--stale-days <n>", "Stale threshold in days for lastVerified", "180")
+  .action(async (options) => {
     const vaultDir = program.opts().vault;
     const vault = new Vault(vaultDir);
     await vault.reindex();
 
-    const noteIds = new Set(vault.index.map((n) => n.id));
-    const issues = [];
+    const { lintVault, hasErrors } = await import("./lib/linter.js");
+    const { formatText, formatJson, formatGitHub } = await import(
+      "./lib/formatters.js"
+    );
 
-    for (const note of vault.index) {
-      if (!note.frontmatter.title) issues.push(`${note.id}: missing title`);
-      if (!note.frontmatter.description)
-        issues.push(`${note.id}: missing description`);
+    const findings = await lintVault(vault, {
+      staleDays: parseInt(options.staleDays, 10),
+    });
 
-      if (note.links) {
-        for (const link of note.links) {
-          if (!noteIds.has(link)) {
-            issues.push(`${note.id}: broken link to ${link}`);
-          }
-        }
-      }
-    }
-
-    if (issues.length === 0) {
-      console.log("✓ No issues found");
+    const fmt = options.format;
+    if (fmt === "json") {
+      console.log(formatJson(findings));
+    } else if (fmt === "github") {
+      for (const line of formatGitHub(findings)) console.log(line);
     } else {
-      console.warn(`⚠ Found ${issues.length} issues:\n`);
-      for (const issue of issues) {
-        console.warn(`  ${issue}`);
-      }
-      process.exit(1);
+      console.log(formatText(findings));
     }
+
+    if (hasErrors(findings)) process.exit(1);
   });
 
 // ===== STATS =====
@@ -365,11 +362,11 @@ description: ""
     spawnSync(editor, [filePath], { stdio: "inherit" });
   });
 
-// ===== LINT =====
+// ===== FIX =====
 program
-  .command("lint")
+  .command("fix")
   .option("--dry-run", "Don't modify files")
-  .description("Auto-fix frontmatter in all notes")
+  .description("Auto-fix frontmatter in all notes (date normalization, missing description, trailing whitespace)")
   .action(async (options) => {
     const vaultDir = program.opts().vault;
     const vault = new Vault(vaultDir);

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,0 +1,63 @@
+import path from "path";
+
+const LEVEL_TO_CMD = {
+  error: "error",
+  warning: "warning",
+  info: "notice",
+};
+
+const LEVEL_SYMBOL = {
+  error: "✗",
+  warning: "⚠",
+  info: "ℹ",
+};
+
+function escapeMessage(msg) {
+  return String(msg).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+/**
+ * GitHub Actions workflow-command output, one line per finding.
+ * GitHub parses `::level file=...::message` from step stdout and attaches
+ * it to the commit. Without `file`, the annotation shows at the top of the
+ * job log (still visible). `line=` pins inline in Files Changed.
+ */
+export function formatGitHub(findings, { cwd = process.cwd() } = {}) {
+  const out = [];
+  for (const f of findings) {
+    const cmd = LEVEL_TO_CMD[f.level] || "notice";
+    const props = [`title=claude-code-vault/${f.code}`];
+    if (f.file) {
+      const parts = [`file=${path.relative(cwd, f.file)}`];
+      if (Number.isInteger(f.line) && f.line > 0) parts.push(`line=${f.line}`);
+      props.unshift(...parts);
+    }
+    out.push(`::${cmd} ${props.join(",")}::${escapeMessage(f.message)}`);
+  }
+  return out;
+}
+
+export function formatJson(findings) {
+  return JSON.stringify(findings, null, 2);
+}
+
+export function formatText(findings, { cwd = process.cwd() } = {}) {
+  if (findings.length === 0) return "✓ No issues found.";
+  const byLevel = { error: 0, warning: 0, info: 0 };
+  for (const f of findings) byLevel[f.level] = (byLevel[f.level] ?? 0) + 1;
+
+  const lines = [];
+  for (const f of findings) {
+    const sym = LEVEL_SYMBOL[f.level] ?? "·";
+    const loc = f.file
+      ? `${path.relative(cwd, f.file)}${f.line ? `:${f.line}` : ""}`
+      : f.noteId;
+    lines.push(`${sym} [${f.code}] ${loc}`);
+    lines.push(`    ${f.message}`);
+  }
+  lines.push("");
+  lines.push(
+    `${byLevel.error} error(s), ${byLevel.warning} warning(s), ${byLevel.info} info`
+  );
+  return lines.join("\n");
+}

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,0 +1,315 @@
+import fs from "fs/promises";
+import path from "path";
+
+/**
+ * Vault linter — checks a reindexed Vault for content-quality issues.
+ *
+ * Finding shape: { level, code, message, noteId, file, line }
+ *   level: "error" | "warning" | "info"
+ *   code:  stable identifier (part of the public contract; don't rename)
+ *   line:  1-based; points at the frontmatter block when field-specific
+ */
+
+const DEFAULT_STALE_DAYS = 180;
+const MIN_BODY_CHARS = 200;
+const MAX_BODY_CHARS = 15000;
+const DUP_THRESHOLD = 0.55;
+
+export async function lintVault(vault, opts = {}) {
+  const staleDays = opts.staleDays ?? DEFAULT_STALE_DAYS;
+  const findings = [];
+  const noteIds = new Set(vault.index.map((n) => n.id));
+
+  const fileCache = new Map();
+  const readFile = async (note) => {
+    if (fileCache.has(note.id)) return fileCache.get(note.id);
+    const abs = path.join(vault.vaultDir, note.path);
+    const raw = await fs.readFile(abs, "utf-8");
+    fileCache.set(note.id, raw);
+    return raw;
+  };
+
+  for (const note of vault.index) {
+    const raw = await readFile(note);
+    const file = path.join(vault.vaultDir, note.path);
+    const lines = splitFrontmatterLines(raw);
+
+    pushMissingFields(findings, note, file, lines);
+    pushUnknownEnums(findings, note, file, lines);
+    pushDeadLinks(findings, note, noteIds, file, raw);
+    pushHeadingSkips(findings, note, file, raw, lines.bodyStartLine);
+    pushSizeFindings(findings, note, file, raw, lines.bodyStartLine);
+    pushStaleDate(findings, note, file, lines, staleDays);
+  }
+
+  pushOrphans(findings, vault);
+  pushDuplicateCandidates(findings, vault);
+
+  return findings;
+}
+
+function splitFrontmatterLines(raw) {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n/);
+  const out = { hasFrontmatter: !!match, fieldLines: new Map(), bodyStartLine: 1 };
+  if (!match) return out;
+  const fmLines = match[1].split("\n");
+  fmLines.forEach((line, i) => {
+    const m = line.match(/^\s*([A-Za-z_]+)\s*:/);
+    if (m) out.fieldLines.set(m[1], i + 2); // +1 for the opening ---, +1 for 1-based
+  });
+  out.bodyStartLine = fmLines.length + 3;
+  return out;
+}
+
+function lineFor(lines, field) {
+  return lines.fieldLines.get(field) ?? 1;
+}
+
+function pushMissingFields(findings, note, file, lines) {
+  if (!note.frontmatter?.title) {
+    findings.push({
+      level: "error",
+      code: "missing-frontmatter-field",
+      message: `Note "${note.id}" has no frontmatter \`title\`. Search and list views will show "undefined".`,
+      noteId: note.id,
+      file,
+      line: 1,
+    });
+  }
+  if (!note.type) {
+    findings.push({
+      level: "warning",
+      code: "missing-frontmatter-field",
+      message: `Note "${note.id}" is missing frontmatter \`type\`. Typed-note schemas and type-aware filters can't apply.`,
+      noteId: note.id,
+      file,
+      line: 1,
+    });
+  }
+  if (!note.frontmatter?.tags || note.frontmatter.tags.length === 0) {
+    findings.push({
+      level: "warning",
+      code: "missing-frontmatter-field",
+      message: `Note "${note.id}" has no frontmatter \`tags\`. Tag filters won't find it.`,
+      noteId: note.id,
+      file,
+      line: 1,
+    });
+  }
+  if (!note.frontmatter?.description && !note.frontmatter?.summary) {
+    findings.push({
+      level: "info",
+      code: "missing-frontmatter-field",
+      message: `Note "${note.id}" has no \`description\` or \`summary\`. Search results won't have a blurb.`,
+      noteId: note.id,
+      file,
+      line: 1,
+    });
+  }
+}
+
+const KNOWN_STATUSES = new Set(["draft", "current", "stale", "deprecated"]);
+const KNOWN_TYPES = new Set([
+  "adr",
+  "feature",
+  "gotcha",
+  "runbook",
+  "glossary",
+  "overview",
+  "architecture",
+  "research",
+]);
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function pushUnknownEnums(findings, note, file, lines) {
+  const s = note.frontmatter?.status;
+  if (s && !KNOWN_STATUSES.has(s)) {
+    findings.push({
+      level: "warning",
+      code: "unknown-status",
+      message: `Note "${note.id}" has unknown status "${s}". Valid: draft, current, stale, deprecated.`,
+      noteId: note.id,
+      file,
+      line: lineFor(lines, "status"),
+    });
+  }
+  const t = note.frontmatter?.type;
+  if (t && !KNOWN_TYPES.has(t)) {
+    findings.push({
+      level: "warning",
+      code: "unknown-type",
+      message: `Note "${note.id}" has unknown type "${t}". Valid: ${[...KNOWN_TYPES].join(", ")}.`,
+      noteId: note.id,
+      file,
+      line: lineFor(lines, "type"),
+    });
+  }
+  const lv = note.frontmatter?.lastVerified;
+  if (lv && !ISO_DATE_RE.test(lv)) {
+    findings.push({
+      level: "warning",
+      code: "invalid-lastverified",
+      message: `Note "${note.id}" has lastVerified "${lv}" — expected YYYY-MM-DD.`,
+      noteId: note.id,
+      file,
+      line: lineFor(lines, "lastVerified"),
+    });
+  }
+}
+
+function pushDeadLinks(findings, note, noteIds, file, raw) {
+  if (!note.links) return;
+  for (const link of note.links) {
+    if (noteIds.has(link)) continue;
+    const re = new RegExp(
+      `\\[\\[${link.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\|[^\\]]+)?\\]\\]`
+    );
+    const lineIdx = raw.split("\n").findIndex((l) => re.test(l));
+    findings.push({
+      level: "error",
+      code: "dead-link",
+      message: `Note "${note.id}" links to "${link}", which doesn't exist.`,
+      noteId: note.id,
+      file,
+      line: lineIdx >= 0 ? lineIdx + 1 : 1,
+    });
+  }
+}
+
+function pushHeadingSkips(findings, note, file, raw, bodyStartLine) {
+  const lines = raw.split("\n");
+  let prevLevel = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(#{1,6})\s+\S/);
+    if (!m) continue;
+    const level = m[1].length;
+    if (prevLevel > 0 && level > prevLevel + 1) {
+      findings.push({
+        level: "warning",
+        code: "heading-skip",
+        message: `Note "${note.id}" jumps from h${prevLevel} to h${level} — chunk breadcrumbs will be awkward.`,
+        noteId: note.id,
+        file,
+        line: i + 1,
+      });
+    }
+    prevLevel = level;
+  }
+}
+
+function pushSizeFindings(findings, note, file, raw, bodyStartLine) {
+  const fmMatch = raw.match(/^---\n[\s\S]*?\n---\n/);
+  const body = fmMatch ? raw.slice(fmMatch[0].length).trim() : raw.trim();
+  if (body.length < MIN_BODY_CHARS) {
+    findings.push({
+      level: "info",
+      code: "undersized-note",
+      message: `Note "${note.id}" is ${body.length} chars — too short to embed usefully (min ${MIN_BODY_CHARS}).`,
+      noteId: note.id,
+      file,
+      line: bodyStartLine,
+    });
+  } else if (body.length > MAX_BODY_CHARS) {
+    findings.push({
+      level: "warning",
+      code: "oversized-note",
+      message: `Note "${note.id}" is ${body.length} chars — consider splitting (soft cap ${MAX_BODY_CHARS}).`,
+      noteId: note.id,
+      file,
+      line: bodyStartLine,
+    });
+  }
+}
+
+function pushStaleDate(findings, note, file, lines, staleDays) {
+  const lv = note.lastVerified;
+  if (!lv || !ISO_DATE_RE.test(lv)) return;
+  if (note.status !== "current") return;
+  const ageDays = Math.floor((Date.now() - Date.parse(lv)) / 86400000);
+  if (ageDays > staleDays) {
+    findings.push({
+      level: "warning",
+      code: "stale-date",
+      message: `Note "${note.id}" is marked \`current\` but lastVerified is ${ageDays} days old (> ${staleDays}).`,
+      noteId: note.id,
+      file,
+      line: lineFor(lines, "lastVerified"),
+    });
+  }
+}
+
+function pushOrphans(findings, vault) {
+  for (const note of vault.index) {
+    if (note.type === "overview") continue;
+    const fwd = note.links?.length ?? 0;
+    const back = vault.getBacklinksFor(note.id).length;
+    if (fwd === 0 && back === 0) {
+      findings.push({
+        level: "info",
+        code: "orphan-note",
+        message: `Note "${note.id}" has no forward links and no backlinks. Consider linking it from a sibling or VAULT_SUMMARY.`,
+        noteId: note.id,
+        file: path.join(vault.vaultDir, note.path),
+        line: 1,
+      });
+    }
+  }
+}
+
+const STOPWORDS = new Set([
+  "the","and","for","with","that","this","have","has","had","are","was","were","been","being","will",
+  "would","could","should","from","into","onto","over","under","about","than","then","there","here",
+  "your","you","our","their","they","them","these","those","which","when","where","what","who","why",
+  "how","not","but","any","all","some","one","two","only","also","such","own","same","use","uses",
+  "used","using","like","very","just","each","both","many","more","most","other","another",
+  "note","notes","vault","file","files",
+]);
+
+function tokenize(text) {
+  return new Set(
+    String(text || "")
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length >= 4 && !STOPWORDS.has(t))
+  );
+}
+
+function jaccard(a, b) {
+  if (!a.size || !b.size) return 0;
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+function pushDuplicateCandidates(findings, vault) {
+  const enriched = vault.index.map((n) => ({
+    id: n.id,
+    title: n.title,
+    tokens: tokenize(
+      `${n.title} ${n.frontmatter?.description ?? ""} ${n.frontmatter?.summary ?? ""} ${n.tags.join(" ")}`
+    ),
+    file: path.join(vault.vaultDir, n.path),
+  }));
+  for (let i = 0; i < enriched.length; i++) {
+    for (let j = i + 1; j < enriched.length; j++) {
+      const score = jaccard(enriched[i].tokens, enriched[j].tokens);
+      if (score >= DUP_THRESHOLD) {
+        findings.push({
+          level: "info",
+          code: "duplicate-candidate",
+          message: `Notes "${enriched[i].id}" and "${enriched[j].id}" look similar (Jaccard ${score.toFixed(2)}). Consider merging or cross-linking.`,
+          noteId: enriched[i].id,
+          related: enriched[j].id,
+          file: enriched[i].file,
+          line: 1,
+          score: Number(score.toFixed(3)),
+        });
+      }
+    }
+  }
+}
+
+export function hasErrors(findings) {
+  return findings.some((f) => f.level === "error");
+}

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -6,6 +6,7 @@ import chokidar from "chokidar";
 import fsSync from "fs";
 import path from "path";
 import { Vault } from "./vault.js";
+import { lintVault } from "./linter.js";
 
 const vaultDir = process.env.VAULT_DIR || "./vault";
 const vault = new Vault(vaultDir);
@@ -152,6 +153,23 @@ server.registerTool(
     }));
     return {
       content: [{ type: "text", text: JSON.stringify(notes, null, 2) }],
+    };
+  })
+);
+
+server.registerTool(
+  "vault_lint",
+  {
+    description:
+      "Lint the vault for content-quality issues: dead wiki-links, missing frontmatter (title/type/tags/description), orphan notes, heading hierarchy skips, oversize/undersize notes, duplicate-candidate pairs (Jaccard on tokens), stale lastVerified dates, and unknown enum values for status/type. Returns findings as a JSON array — each finding has { level: 'error'|'warning'|'info', code, message, noteId, file, line }. Codes are stable (e.g. 'dead-link', 'missing-frontmatter-field'). Call this to check vault health before authoring new notes, or after large refactors.",
+    inputSchema: {
+      staleDays: z.number().int().positive().optional(),
+    },
+  },
+  safe(async ({ staleDays }) => {
+    const findings = await lintVault(vault, { staleDays });
+    return {
+      content: [{ type: "text", text: JSON.stringify(findings, null, 2) }],
     };
   })
 );

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -53,19 +53,18 @@ export class Vault {
   async _scanDir(dir) {
     try {
       const entries = await fs.readdir(dir, { withFileTypes: true });
+      const atRoot = path.resolve(dir) === this.vaultDir;
 
       for (const entry of entries) {
         const fullPath = path.join(dir, entry.name);
 
         if (entry.isDirectory()) {
-          // Recurse into subdirectories
           await this._scanDir(fullPath);
         } else if (entry.isFile() && entry.name.endsWith(".md")) {
-          // Index this markdown file
+          // Skip top-level README.md — it's vault-schema meta-docs, not a note.
+          if (atRoot && entry.name.toLowerCase() === "readme.md") continue;
           const note = await this._indexFile(fullPath);
-          if (note) {
-            this.index.push(note);
-          }
+          if (note) this.index.push(note);
         }
       }
     } catch (err) {
@@ -194,9 +193,14 @@ export class Vault {
 
   /**
    * Extract backlinks from content (e.g., [[note-id]] or [[note-id|label]]).
+   * Skips content inside inline code spans and fenced code blocks — wiki-link
+   * syntax shown as an example shouldn't count as a real edge.
    */
   _extractBacklinks(content) {
-    const matches = content.match(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g) || [];
+    const stripped = content
+      .replace(/```[\s\S]*?```/g, "")
+      .replace(/`[^`\n]*`/g, "");
+    const matches = stripped.match(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g) || [];
     return matches
       .map((m) => m.replace(/\[\[([^\]|]+).*\]\]/, "$1").trim())
       .filter((link) => link.length > 0);


### PR DESCRIPTION
## Summary

- New `claude-code-vault lint` CLI command + `vault_lint` MCP tool that checks vault health and emits findings with stable codes.
- Nine rules: `dead-link`, `missing-frontmatter-field`, `orphan-note`, `heading-skip`, `undersized-note`, `oversized-note`, `duplicate-candidate`, `stale-date`, `unknown-status` / `unknown-type` / `invalid-lastverified`.
- Three output formats (`text`, `json`, `github`). `github` emits GitHub Actions workflow commands so findings annotate PRs directly. CI wired up to fail on error-level findings.
- CLI rename: old `lint` (auto-fixer) → `fix`. Old `check` (basic validator) → subsumed by new `lint`.

## Type of change

- [x] New retrieval technique / MCP tool / CLI command

## Checks

- [x] `npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js` passes
- [x] CLI smoke: `node index.js lint` runs clean against our boilerplate vault
- [x] `node index.js lint --format json` and `--format github` emit valid output against a fixture with intentional violations
- [x] `node test/retrieval/eval.js` still green — zero recall regression
- [x] `vault_lint` MCP tool registered and wired to the same `lintVault()` entry point
- [x] Updated `README.md` roadmap + `CONTRIBUTING.md` pre-PR checklist
- [x] No new runtime dependencies

## Notes

### Parser fixes caught by dogfooding

Two real bugs surfaced the first time I pointed the linter at our own vault:

1. **Wiki-links inside code spans were counted as real edges.** `[[gotchas]]` shown as a don't-do-this example in `vault/README.md` was producing a dead-link finding. Fixed `_extractBacklinks` to strip inline code spans and fenced code blocks before extracting wiki-links.
2. **Top-level `vault/README.md` was being indexed as a note.** It's vault-schema meta-docs. Scanner now skips `README.md` at the vault root only — nested READMEs inside project folders are still indexed.

### CLI rename risk

The old `lint` command (auto-fixer) is renamed to `fix`; the old `check` (basic validator) is removed in favor of the new `lint`. Anyone scripting against `claude-code-vault lint` expecting auto-fixes will break. At 0.1.x this is acceptable and the new naming matches industry conventions (lint = check, fix = write).

### Scope choices

- Line numbers resolved inline in the linter (reads each file once), not in the vault parser — smaller blast radius.
- Orphan rule exempts `type: overview` (uses the `type` field from #18).
- Stale threshold defaults to 180 days via `--stale-days`.

Unblocks #20 (typed-note schemas) and #21 (status-aware retrieval).