### PR TITLE
feat: per-type note schemas + demo runbook/glossary notes

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,8 +323,12 @@ program
 // ===== ADD =====
 program
   .command("add <path> <title>")
+  .option(
+    "--type <t>",
+    "Note type (adr | feature | gotcha | runbook | glossary). Scaffolds a per-type template."
+  )
   .description("Create a new note")
-  .action(async (pathStr, title) => {
+  .action(async (pathStr, title, options) => {
     const vaultDir = program.opts().vault;
     const slug = title
       .toLowerCase()
@@ -342,10 +346,14 @@ program
 
     await fs.mkdir(path.dirname(filePath), { recursive: true });
 
-    const pathParts = pathStr.split("/");
-    const tags = pathParts.slice(0, 2);
-
-    const content = `---
+    let content;
+    if (options.type) {
+      const { templateFor } = await import("./lib/schemas.js");
+      content = templateFor(options.type, title);
+    } else {
+      const pathParts = pathStr.split("/");
+      const tags = pathParts.slice(0, 2);
+      content = `---
 title: ${title}
 tags: [${tags.join(", ")}]
 date: ${new Date().toISOString().split("T")[0]}
@@ -354,6 +362,7 @@ description: ""
 
 # ${title}
 `;
+    }
 
     await fs.writeFile(filePath, content);
     console.log(`✓ Created ${filePath}`);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
+import { SCHEMAS } from "./schemas.js";
 
 /**
  * Vault linter — checks a reindexed Vault for content-quality issues.
@@ -40,6 +41,7 @@ export async function lintVault(vault, opts = {}) {
     pushHeadingSkips(findings, note, file, raw, lines.bodyStartLine);
     pushSizeFindings(findings, note, file, raw, lines.bodyStartLine);
     pushStaleDate(findings, note, file, lines, staleDays);
+    pushTypedSchema(findings, note, file, raw, lines.bodyStartLine);
   }
 
   pushOrphans(findings, vault);
@@ -236,6 +238,126 @@ function pushStaleDate(findings, note, file, lines, staleDays) {
       line: lineFor(lines, "lastVerified"),
     });
   }
+}
+
+function pushTypedSchema(findings, note, file, raw, bodyStartLine) {
+  const schema = SCHEMAS[note.type];
+  if (!schema) return;
+
+  const fmMatch = raw.match(/^---\n[\s\S]*?\n---\n/);
+  const body = fmMatch ? raw.slice(fmMatch[0].length) : raw;
+  const bodyLines = body.split("\n");
+
+  const headings = [];
+  bodyLines.forEach((line, i) => {
+    const m = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (m) headings.push({ level: m[1].length, text: m[2].trim(), line: bodyStartLine + i });
+  });
+  const h2Texts = new Set(headings.filter((h) => h.level === 2).map((h) => h.text));
+
+  if (schema.requiredHeadings) {
+    for (const h of schema.requiredHeadings) {
+      if (!h2Texts.has(h)) {
+        findings.push({
+          level: "warning",
+          code: "missing-required-section",
+          message: `Note "${note.id}" (type: ${note.type}) is missing required H2 section "## ${h}".`,
+          noteId: note.id,
+          file,
+          line: bodyStartLine,
+        });
+      }
+    }
+  }
+
+  if (schema.requiredSubsection) {
+    const hasH3 = headings.some(
+      (h) => h.level === 3 && h.text === schema.requiredSubsection
+    );
+    if (!hasH3) {
+      findings.push({
+        level: "warning",
+        code: "missing-required-section",
+        message: `Note "${note.id}" (type: ${note.type}) is missing at least one "### ${schema.requiredSubsection}" subsection.`,
+        noteId: note.id,
+        file,
+        line: bodyStartLine,
+      });
+    }
+  }
+
+  if (schema.requiredBoldLabels) {
+    const h2Sections = splitIntoH2Sections(body, bodyStartLine);
+    if (h2Sections.length === 0) {
+      findings.push({
+        level: "warning",
+        code: "missing-required-section",
+        message: `Note "${note.id}" (type: gotcha) has no H2 sections — each gotcha should be its own H2 block.`,
+        noteId: note.id,
+        file,
+        line: bodyStartLine,
+      });
+    }
+    for (const section of h2Sections) {
+      for (const label of schema.requiredBoldLabels) {
+        const re = new RegExp(`\\*\\*${label}\\*\\*\\s*[:：]?`, "i");
+        if (!re.test(section.body)) {
+          findings.push({
+            level: "warning",
+            code: "missing-bold-label",
+            message: `Note "${note.id}" gotcha "## ${section.heading}" is missing the **${label}** label.`,
+            noteId: note.id,
+            file,
+            line: section.line,
+          });
+        }
+      }
+    }
+  }
+
+  if (schema.requiresFrontmatterTerms) {
+    const terms = note.frontmatter?.terms ?? [];
+    if (terms.length === 0) {
+      findings.push({
+        level: "warning",
+        code: "missing-glossary-terms",
+        message: `Note "${note.id}" (type: glossary) has no \`terms:\` list in frontmatter.`,
+        noteId: note.id,
+        file,
+        line: 1,
+      });
+    } else {
+      for (const term of terms) {
+        if (!h2Texts.has(term)) {
+          findings.push({
+            level: "warning",
+            code: "missing-glossary-term-section",
+            message: `Glossary "${note.id}" declares term "${term}" but has no "## ${term}" section.`,
+            noteId: note.id,
+            file,
+            line: bodyStartLine,
+          });
+        }
+      }
+    }
+  }
+}
+
+function splitIntoH2Sections(body, bodyStartLine) {
+  const lines = body.split("\n");
+  const sections = [];
+  let current = null;
+  lines.forEach((line, i) => {
+    const m = line.match(/^##\s+(.+?)\s*$/);
+    if (m) {
+      if (current) sections.push(current);
+      current = { heading: m[1].trim(), line: bodyStartLine + i, body: "" };
+    } else if (current) {
+      current.body += line + "\n";
+    }
+  });
+  if (current) sections.push(current);
+  return sections;
 }
 
 function pushOrphans(findings, vault) {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,0 +1,101 @@
+/**
+ * Per-type note schemas — rules the linter enforces and templates the CLI
+ * scaffolds. The schema for each type is intentionally minimal: just the
+ * structure that materially improves retrieval (so chunks have predictable
+ * breadcrumbs and bold labels are findable by keyword search).
+ *
+ * Types not listed here (overview, architecture, research) have no body
+ * schema — only the universal frontmatter rules apply.
+ */
+
+export const SCHEMAS = {
+  adr: {
+    requiredHeadings: ["Context", "Decision", "Alternatives", "Consequences"],
+  },
+  feature: {
+    requiredHeadings: ["What", "Why", "How"],
+  },
+  runbook: {
+    requiredHeadings: ["Steps"],
+    requiredSubsection: "Verify",
+  },
+  gotcha: {
+    requiredBoldLabels: ["Symptom", "Cause", "Fix"],
+  },
+  glossary: {
+    requiresFrontmatterTerms: true,
+  },
+};
+
+const today = () => new Date().toISOString().split("T")[0];
+
+export function templateFor(type, title) {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-");
+  const fm = (extra = "") =>
+    `---
+title: ${title}
+type: ${type}
+status: current
+date: ${today()}
+lastVerified: ${today()}
+description: ""
+summary: ""
+tags: [${slug}]${extra}
+---
+
+# ${title}
+`;
+
+  switch (type) {
+    case "adr":
+      return (
+        fm() +
+        `\n## Context\n\nWhat was the situation that forced a decision?\n\n## Decision\n\nWhat did we decide?\n\n## Alternatives\n\nWhat else did we consider, and why did we reject it?\n\n## Consequences\n\nWhat are the trade-offs we accept?\n`
+      );
+    case "feature":
+      return (
+        fm() +
+        `\n## What\n\nWhat does this feature do, in one paragraph?\n\n## Why\n\nWhy did we build it? What problem does it solve?\n\n## How\n\nHow does it work? Cover the user-visible flow and any non-obvious internals.\n`
+      );
+    case "runbook":
+      return (
+        fm() +
+        `\n## Steps\n\n### 1. First step\n\nWhat to do.\n\n### Verify\n\nHow to confirm the step succeeded.\n\n### 2. Second step\n\nWhat to do.\n\n### Verify\n\nHow to confirm the step succeeded.\n`
+      );
+    case "gotcha":
+      return (
+        fm() +
+        `\n## First gotcha\n\n**Symptom**: What the user sees.\n\n**Cause**: Why it happens.\n\n**Fix**: What to do about it.\n`
+      );
+    case "glossary":
+      return (
+        `---
+title: ${title}
+type: glossary
+status: current
+date: ${today()}
+lastVerified: ${today()}
+description: ""
+summary: ""
+tags: [${slug}, glossary]
+terms: [TermOne, TermTwo]
+---
+
+# ${title}
+
+## TermOne
+
+Definition for TermOne.
+
+## TermTwo
+
+Definition for TermTwo.
+`
+      );
+    default:
+      return fm();
+  }
+}

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -151,6 +151,12 @@ export class Vault {
         result.tags = match
           ? match[1].split(",").map((t) => t.trim())
           : [];
+      } else if (k === "terms") {
+        // terms: [TermOne, TermTwo] (used by glossary notes)
+        const match = value.match(/\[(.*?)\]/);
+        result.terms = match
+          ? match[1].split(",").map((t) => t.trim()).filter(Boolean)
+          : [];
       } else if (k === "date") {
         result.date = value;
       } else if (k === "description") {

--- a/vault/README.md
+++ b/vault/README.md
@@ -82,6 +82,23 @@ lastVerified: 2026-04-20
 # Note Content
 ```
 
+## Per-type note schemas
+
+When a note sets `type:`, the linter enforces a minimal body schema for that type. The goal is predictable retrieval — chunks have the same breadcrumbs and bold labels across notes of the same kind, so keyword search finds them and LLMs can scan them consistently.
+
+Scaffold a new note with the right shape via `claude-code-vault add <path> "<title>" --type <t>`.
+
+| Type | Required structure | Rationale |
+|---|---|---|
+| `adr` | H2 sections: `## Context`, `## Decision`, `## Alternatives`, `## Consequences` | Standard ADR format; these are the four questions every decision record answers. |
+| `feature` | H2 sections: `## What`, `## Why`, `## How` | Enough to explain a user-visible feature without prescribing a rigid template. |
+| `runbook` | An `## Steps` H2, and at least one `### Verify` H3 subsection | Every step should be independently verifiable — no blind runbooks. |
+| `gotcha` | Each H2 section contains bold labels `**Symptom**`, `**Cause**`, `**Fix**` | Gotchas are scanned under pressure; the labels make the triage info findable. |
+| `glossary` | Frontmatter `terms: [A, B, C]` list, and a matching `## A`, `## B`, `## C` H2 for each | Declarative term list lets the linter catch drift between what's declared and what's defined. |
+| `overview` / `architecture` / `research` | No body schema — only the universal frontmatter rules apply | These are free-form narrative; forcing structure would hurt more than help. |
+
+Types not in the table above warn as `unknown-type`. See [[claude-code-vault/gotchas/gotchas]] for the full enum.
+
 ## Starting a new project
 
 1. `mkdir vault/new-project/`

--- a/vault/claude-code-vault/VAULT_SUMMARY.md
+++ b/vault/claude-code-vault/VAULT_SUMMARY.md
@@ -18,6 +18,8 @@ This vault doubles as documentation for `claude-code-vault` itself and as the re
 - New here? → [[claude-code-vault/overview]]
 - Want to use the search API? → [[claude-code-vault/features/semantic-search]]
 - Hitting an install or runtime error? → [[claude-code-vault/gotchas/gotchas]]
+- Cutting a release? → [[claude-code-vault/runbooks/publish-release]]
+- Confused by a term? → [[claude-code-vault/glossary/core-terms]]
 - Curious *why* the stack looks the way it does? → [[claude-code-vault/adrs/adr-001-local-first-embeddings]]
 - Looking ahead? → [[claude-code-vault/research/roadmap]]
 
@@ -27,4 +29,6 @@ This vault doubles as documentation for `claude-code-vault` itself and as the re
 - `architecture/` — how the moving parts fit together
 - `features/` — user-facing capabilities and how to invoke them
 - `gotchas/` — real failure modes and their fixes
+- `runbooks/` — step-by-step operational procedures
+- `glossary/` — canonical definitions of domain vocabulary
 - `research/` — open questions and forward-looking notes

--- a/vault/claude-code-vault/adrs/adr-001-local-first-embeddings.md
+++ b/vault/claude-code-vault/adrs/adr-001-local-first-embeddings.md
@@ -22,15 +22,23 @@ The package is pitched as "local-first." That promise breaks if the first thing 
 - **Vector store:** `sqlite-vec` (`vec0` virtual table) inside the same `better-sqlite3` database that holds the chunk and note metadata.
 - **Cache location:** `.vault-cache/embeddings-vN.db` (filename versioned — see [[claude-code-vault/gotchas/gotchas]] on cache filename bumps).
 
-## Rationale
+Why this beats the alternatives:
 
 - **No API key required.** The package works the moment `npm install` finishes and the model has downloaded once (~25 MB).
 - **One file = one index.** SQLite is the only durable artifact. Wipe `.vault-cache/` to fully reset.
 - **Filter and rank in one query.** sqlite-vec lets us pre-filter rowids by tag / date / type / id-prefix, then KNN-rank inside the filtered set. No second-pass filtering in JS. See [[claude-code-vault/architecture/embeddings-pipeline]].
 - **Small enough to ship anywhere.** MiniLM-L6 runs in ~100 ms per chunk on a laptop CPU. Larger models are not worth the trade for a personal vault.
 
-## Trade-offs accepted
+## Alternatives
+
+- **Remote embedding API (OpenAI `text-embedding-3-small`, Voyage, Cohere).** Higher recall, especially on jargon. Rejected because it requires an API key on first run, incurs per-query cost, and makes the package unusable offline or in air-gapped environments — breaking the "local-first" promise.
+- **Larger on-device model (e.g. `bge-large-en`, 1024-dim).** Better recall. Rejected because embed time jumps ~4× on a laptop CPU and the cache file grows proportionally; the recall gain does not justify the friction for a personal-vault workload.
+- **No vector search at all — only keyword search.** Simplest. Rejected because users routinely phrase queries that don't share lexical tokens with the target note (e.g. "why is install slow" → note titled "NODE_MODULE_VERSION mismatch").
+- **Separate vector DB (Chroma, Qdrant, LanceDB).** More featureful. Rejected because it adds a second durable artifact, a second install step, and usually a daemon — all of which fight the "one `npm install` and go" posture.
+
+## Consequences
 
 - Recall on jargon-heavy queries is lower than a frontier model would give. Mitigated by [[claude-code-vault/features/semantic-search]]'s opt-in HyDE flag, which uses Anthropic's API only when the user explicitly asks for it.
 - Re-embedding the whole vault on a model change is expensive. Mitigated by versioning the cache filename so old indexes are abandoned cleanly rather than silently corrupted.
 - `better-sqlite3` is a native module — version bumps occasionally break installs on fresh machines. See [[claude-code-vault/gotchas/gotchas]].
+- Model download (~25 MB) happens on first run; CI environments that don't cache `node_modules` or the Hugging Face cache pay it every build.

--- a/vault/claude-code-vault/features/graph-expansion.md
+++ b/vault/claude-code-vault/features/graph-expansion.md
@@ -11,16 +11,24 @@ tags: [graph, wiki-links, related]
 
 # Graph expansion via wiki-links
 
-Wiki-links in note bodies form a directed graph between notes. `vault_related` and `read-with-context` walk that graph to surface neighbors — useful when a single note answers part of a question and the rest lives one hop away.
+## What
 
-## Public surface
+Wiki-links in note bodies form a directed graph between notes. `vault_related` and `read-with-context` walk that graph to surface neighbors — useful when a single note answers part of a question and the rest lives one hop away. Each neighbor comes back with its direction (forward / backward / bidirectional), edge weight, and a short snippet.
+
+## Why
+
+Retrieval over a single note often returns the right *starting point* but not enough surrounding context. The wiki-link graph is a hand-curated signal — when an author writes `[[other-note]]`, they're marking a connection a pure-embedding ranker can't see. Walking that graph complements semantic search (see [[claude-code-vault/features/semantic-search]]) rather than replacing it.
+
+## How
+
+### Public surface
 
 - **CLI:** `claude-code-vault related <id>` and `claude-code-vault read-with-context <id>`
 - **MCP:** the `vault_related` tool
 
 Both accept a `depth` parameter (default 1, capped at 2) and a `limit` on how many neighbors to return.
 
-## What gets returned
+### What gets returned
 
 Each neighbor includes:
 
@@ -30,7 +38,7 @@ Each neighbor includes:
 - `weight` — number of edges between the two notes
 - a short snippet of the neighbor's body so a downstream LLM can decide whether to expand it
 
-## Ranking
+### Ranking
 
 Neighbors are ranked:
 
@@ -39,6 +47,6 @@ Neighbors are ranked:
 3. Then by `lastModified` descending — fresher notes bubble up.
 4. Then by id for determinism.
 
-## When to use depth=2
+### When to use depth=2
 
 Depth 1 is the right default — it returns immediate neighbors and is usually sufficient. Depth 2 is for "what's in the broader neighborhood" — useful when seeding a chat with context, expensive when answering a precise question.

--- a/vault/claude-code-vault/features/semantic-search.md
+++ b/vault/claude-code-vault/features/semantic-search.md
@@ -11,9 +11,21 @@ tags: [search, embeddings, mcp, cli]
 
 # Semantic search
 
-Semantic search returns notes (or chunks) ranked by cosine similarity between the query embedding and the indexed embeddings. Filters are applied **before** ranking — see [[claude-code-vault/architecture/embeddings-pipeline]] for the SQL.
+## What
 
-## From the CLI
+Semantic search returns notes (or chunks) ranked by cosine similarity between the query embedding and the indexed embeddings. Three tools ship today: `semantic-search` (note-level), `search-chunks` (paragraph-level), and `search-with-context` (chunks plus graph neighbors). All three support the same filter set — tag, type, id-prefix, date range.
+
+## Why
+
+Keyword search misses queries that don't share lexical tokens with the target note ("why is install slow" vs. "NODE_MODULE_VERSION mismatch"). Embeddings close that gap without requiring a remote API — the decision to keep embeddings local is recorded in [[claude-code-vault/adrs/adr-001-local-first-embeddings]].
+
+Filters are applied **before** ranking — see [[claude-code-vault/architecture/embeddings-pipeline]] for the SQL — so `--type adr --tag embeddings` is precise, not a best-effort post-filter.
+
+## How
+
+Three entry points, same filter set:
+
+### From the CLI
 
 ```bash
 claude-code-vault semantic-search "why did we choose local embeddings"
@@ -23,7 +35,7 @@ claude-code-vault search-with-context "cache filename bump" --type adr
 
 `semantic-search` collapses to the note level (best for "find me the doc"). `search-chunks` returns individual chunks (best for "find me the paragraph"). `search-with-context` returns chunks plus their neighbors (best for feeding into an LLM context window).
 
-## From MCP
+### From MCP
 
 ```json
 {
@@ -38,7 +50,7 @@ claude-code-vault search-with-context "cache filename bump" --type adr
 
 The same three tools (`vault_semantic_search`, `vault_search_chunks`, `vault_search_chunks_with_context`) all accept the same filter set documented in [[claude-code-vault/architecture/cli]].
 
-## Common filter recipes
+### Common filter recipes
 
 - **"Only ADRs":** `--type adr` (or `"type": "adr"` over MCP).
 - **"Only the auth subsystem":** `--id-prefix auth/` if your notes are organized by folder-as-prefix.
@@ -47,7 +59,7 @@ The same three tools (`vault_semantic_search`, `vault_search_chunks`, `vault_sea
 
 Filters compose — `--type adr --tag embeddings` returns ADRs tagged `embeddings`.
 
-## When to turn on HyDE
+### When to turn on HyDE
 
 HyDE expands the query through a small Anthropic model before embedding it. Add `--hyde` (CLI) or `"hyde": true` (MCP) when:
 

--- a/vault/claude-code-vault/glossary/core-terms.md
+++ b/vault/claude-code-vault/glossary/core-terms.md
@@ -1,0 +1,47 @@
+---
+id: core-terms
+title: Core terms
+description: Vocabulary used throughout the claude-code-vault codebase and docs
+summary: Glossary — Vault, Note, Chunk, Backlink, HyDE, MCP, Embedding, Cache. Each term has its own H2 section matching the frontmatter `terms:` list so the linter can verify coverage.
+type: glossary
+status: current
+lastVerified: 2026-04-20
+tags: [glossary, reference]
+terms: [Vault, Note, Chunk, Backlink, HyDE, MCP, Embedding, Cache]
+---
+
+# Core terms
+
+This note is the canonical source for domain vocabulary in `claude-code-vault`. Each term has its own H2 section so retrieval can return the definition on its own, and the frontmatter `terms:` list lets the linter catch drift between the declared vocabulary and what the file actually defines.
+
+## Vault
+
+A directory of markdown notes that `claude-code-vault` indexes, searches, and exposes to Claude. One working copy typically holds one Vault; large projects may nest sub-vaults by folder.
+
+## Note
+
+A single `.md` file inside a Vault, with YAML frontmatter on top and markdown body below. The unit of retrieval for `vault_list` and the unit of similarity for `vault_related`.
+
+## Chunk
+
+A sub-note slice produced by the embeddings pipeline — roughly one H2 or H3 section. Chunks are what `search-chunks` ranks; they're smaller than Notes so retrieval can point at the right paragraph instead of the whole file.
+
+## Backlink
+
+A `[[note-id]]` reference from one Note to another, tracked as a directed edge in the vault graph. Used by `vault_related` and by the orphan-detection rule in the linter.
+
+## HyDE
+
+"Hypothetical Document Embeddings" — an optional query expansion that asks an LLM to draft a plausible answer, then embeds *that* answer instead of the raw question. Enabled with `--hyde`; requires `ANTHROPIC_API_KEY`.
+
+## MCP
+
+Model Context Protocol — the JSON-RPC-over-stdio protocol Claude Code uses to talk to external tools. `claude-code-vault mcp` starts an MCP server that exposes vault operations as tools.
+
+## Embedding
+
+A dense vector representing a Chunk's meaning, produced by a local model and stored in a SQLite table via `sqlite-vec`. Similarity is cosine distance between embeddings.
+
+## Cache
+
+The `.vault-cache/` directory that stores the embeddings DB. Filename encodes schema version (`embeddings-v2.db`); bumping the schema means writing a new filename and abandoning the old one. See [[claude-code-vault/gotchas/gotchas]].

--- a/vault/claude-code-vault/gotchas/gotchas.md
+++ b/vault/claude-code-vault/gotchas/gotchas.md
@@ -11,52 +11,60 @@ tags: [troubleshooting, install, runtime]
 
 # Gotchas
 
-Each gotcha is one section so it can be retrieved on its own.
+Each gotcha is one H2 section so it can be retrieved on its own. Every section follows the **Symptom / Cause / Fix** schema enforced by the linter.
 
 ## `NODE_MODULE_VERSION` mismatch on install
 
-Symptom: `Error: The module was compiled against a different Node.js version` from `better-sqlite3`.
+**Symptom**: `Error: The module was compiled against a different Node.js version` from `better-sqlite3`.
 
-Cause: `better-sqlite3` is a native module pinned to a Node ABI. Installing on Node 20 and running on Node 22 (or vice versa) breaks.
+**Cause**: `better-sqlite3` is a native module pinned to a Node ABI. Installing on Node 20 and running on Node 22 (or vice versa) breaks.
 
-Fix: `rm -rf node_modules .vault-cache && npm install` on the Node version you actually run with. Use `node --version` to confirm.
+**Fix**: `rm -rf node_modules .vault-cache && npm install` on the Node version you actually run with. Use `node --version` to confirm.
 
 ## sqlite-vec rowid must be qualified
 
-Symptom: `ambiguous column: rowid` when joining `vec_chunks` with `note_chunks`.
+**Symptom**: `ambiguous column: rowid` when joining `vec_chunks` with `note_chunks`.
 
-Cause: `sqlite-vec`'s `vec0` virtual table exposes `rowid` and so does `note_chunks`. Unqualified `rowid` is rejected.
+**Cause**: `sqlite-vec`'s `vec0` virtual table exposes `rowid` and so does `note_chunks`. Unqualified `rowid` is rejected.
 
-Fix: always write `v.rowid` and `c.rowid` explicitly in joins. See the SQL in [[claude-code-vault/architecture/embeddings-pipeline]].
+**Fix**: always write `v.rowid` and `c.rowid` explicitly in joins. See the SQL in [[claude-code-vault/architecture/embeddings-pipeline]].
 
 ## Cache filename bump required after schema or model changes
 
-Symptom: weird ranking, missing chunks, or runtime errors after pulling a new version.
+**Symptom**: weird ranking, missing chunks, or runtime errors after pulling a new version.
 
-Cause: `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables — schema changes don't apply on top of an old DB.
+**Cause**: `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables — schema changes don't apply on top of an old DB.
 
-Fix: any change to schema, chunking, or embedding model bumps the cache filename (e.g. `embeddings-v2.db` → `embeddings-v3.db`). Old DB is abandoned, not migrated. Users delete `.vault-cache/` to fully reset.
+**Fix**: any change to schema, chunking, or embedding model bumps the cache filename (e.g. `embeddings-v2.db` → `embeddings-v3.db`). Old DB is abandoned, not migrated. Users delete `.vault-cache/` to fully reset.
 
 ## Stdout discipline in the MCP server
 
-Symptom: MCP client reports "invalid JSON-RPC frame" and disconnects.
+**Symptom**: MCP client reports "invalid JSON-RPC frame" and disconnects.
 
-Cause: anything written to `stdout` from the server process collides with the JSON-RPC stream.
+**Cause**: anything written to `stdout` from the server process collides with the JSON-RPC stream.
 
-Fix: all logs go through `console.error` (stderr). Never `console.log` from server code paths. Same applies to dependencies — vet any new package that might log to stdout.
+**Fix**: all logs go through `console.error` (stderr). Never `console.log` from server code paths. Same applies to dependencies — vet any new package that might log to stdout.
 
 ## `chokidar` reindexes the whole file on every save
 
-Symptom: editor "save on keypress" plugins cause CPU spikes during indexing.
+**Symptom**: editor "save on keypress" plugins cause CPU spikes during indexing.
 
-Cause: each save event triggers a per-file reindex. There is no debounce by design — staleness during a typing session is worse than CPU.
+**Cause**: each save event triggers a per-file reindex. There is no debounce by design — staleness during a typing session is worse than CPU.
 
-Fix: this is intentional. If you genuinely need debouncing, wrap the watcher in your own consumer; don't change the library default.
+**Fix**: this is intentional. If you genuinely need debouncing, wrap the watcher in your own consumer; don't change the library default.
 
-## `ANTHROPIC_API_KEY` should never be committed
+## `ANTHROPIC_API_KEY` leaks if committed
 
-The HyDE feature reads `ANTHROPIC_API_KEY` from the environment when enabled. Keep it in `.env` (already gitignored) or your shell profile. The codebase never logs the key value, but a leaked `.env` would still leak it.
+**Symptom**: API key visible in git history or on GitHub after a push.
 
-## Don't `--no-verify` or `--squash`
+**Cause**: HyDE reads `ANTHROPIC_API_KEY` from the environment; a committed `.env` ships it too. The codebase never logs the key value, but the file itself would leak.
 
-Project convention: always run pre-commit hooks; always merge PRs with `gh pr merge --merge` (no squash). Squash-merging this repo loses the per-commit context that the docs reference.
+**Fix**: keep the key in `.env` (already in `.gitignore`) or your shell profile. If it lands in history, rotate the key before anything else — purging history doesn't recall copies.
+
+## Never `--no-verify` or `--squash`
+
+**Symptom**: history loses per-commit context; PR references in docs go stale.
+
+**Cause**: squash-merging collapses the commit trail that this repo's docs point at, and `--no-verify` skips the hooks that catch the breakage before it ships.
+
+**Fix**: merge PRs with `gh pr merge --merge --delete-branch`. Always run pre-commit hooks. If a hook fails, fix the root cause — don't bypass it.

--- a/vault/claude-code-vault/runbooks/publish-release.md
+++ b/vault/claude-code-vault/runbooks/publish-release.md
@@ -1,0 +1,98 @@
+---
+id: publish-release
+title: Publish a release
+description: Step-by-step runbook for cutting and publishing a new claude-code-vault release to npm and GitHub
+summary: Runbook — bump version, update changelog, tag, push, merge PR with `gh pr merge --merge`, publish to npm, verify `npx` install. Each step has a Verify subsection so you know it succeeded.
+type: runbook
+status: current
+lastVerified: 2026-04-20
+tags: [release, ops, npm]
+---
+
+# Publish a release
+
+How to cut a new `claude-code-vault` release. Every step ends with a **Verify** subsection — if verify fails, stop and investigate before moving on. Don't skip ahead.
+
+## Steps
+
+### 1. Pre-flight checks on `main`
+
+On a fresh clone of `main`:
+
+```bash
+git pull origin main
+npm ci
+node index.js lint
+npm run eval
+```
+
+Lint must be clean. Eval must meet the recall floor the repo ships with.
+
+### Verify
+
+`node index.js lint` prints `✓ No issues found.` and exits 0. Eval prints a recall@5 number at or above the baseline in [[claude-code-vault/research/roadmap]].
+
+### 2. Bump version + update changelog
+
+Edit `package.json` — bump `version` by patch / minor / major per semver.
+
+Draft a short changelog entry in the PR body (or `CHANGELOG.md` if one exists). Mention every merged PR since the last release.
+
+### Verify
+
+`node -p "require('./package.json').version"` prints the new version. `git diff package.json` shows only the version line changed.
+
+### 3. Commit + open release PR
+
+```bash
+git checkout -b release/vX.Y.Z
+git add package.json
+git commit -m "release: vX.Y.Z"
+git push -u origin release/vX.Y.Z
+gh pr create --title "release: vX.Y.Z" --body "<changelog>"
+```
+
+Wait for CI to go green. **Never** merge red.
+
+### Verify
+
+`gh pr checks` shows every check ✓. No reviewer has blocking comments.
+
+### 4. Merge with `--merge` (never `--squash`)
+
+```bash
+gh pr merge --merge --delete-branch
+```
+
+Squash-merge would collapse the per-commit history that the self-docs reference. See [[claude-code-vault/gotchas/gotchas]] for why.
+
+### Verify
+
+`git log main --oneline | head` shows the merge commit and the version bump as separate commits. The release branch is gone locally and on the remote.
+
+### 5. Tag and publish to npm
+
+```bash
+git checkout main && git pull
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+npm publish
+```
+
+### Verify
+
+`npm view claude-code-vault version` prints the new version. `gh release view vX.Y.Z` shows the tag on GitHub.
+
+### 6. Smoke-test the published package
+
+In a scratch directory:
+
+```bash
+mkdir /tmp/ccv-smoke && cd /tmp/ccv-smoke
+npx claude-code-vault@latest init demo
+npx claude-code-vault index --vault vault
+```
+
+### Verify
+
+`init` creates the folder tree. `index` reports a non-zero note count without errors. Delete `/tmp/ccv-smoke` when done.


### PR DESCRIPTION
## Summary

Closes #20. Adds **per-type note schemas** (the last open Phase 2 content-quality item) — the linter now verifies typed notes follow a minimal body contract so chunks have predictable breadcrumbs and bold labels across notes of the same kind.

- `lib/schemas.js`: central `SCHEMAS` table (adr, feature, runbook, gotcha, glossary) + `templateFor(type, title)` scaffolds.
- `lib/linter.js` new rules: `missing-required-section`, `missing-bold-label`, `missing-glossary-terms`, `missing-glossary-term-section`.
- `lib/vault.js`: frontmatter now parses `terms: [...]`.
- CLI: `claude-code-vault add <path> "<title>" --type <t>` scaffolds from the template; default behavior unchanged when `--type` is omitted.
- Self-docs vault now dogfoods every schema:
  - `gotchas/gotchas.md` rewritten with `**Symptom** / **Cause** / **Fix**` labels per H2.
  - `adrs/adr-001-local-first-embeddings.md` gains `## Alternatives` + `## Consequences`.
  - Both `features/*.md` notes gain `## What / ## Why / ## How`.
  - **NEW** `runbooks/publish-release.md` — each step has a `### Verify` subsection.
  - **NEW** `glossary/core-terms.md` — frontmatter `terms:` list matched by H2 sections.
  - `VAULT_SUMMARY.md` links the new notes so they aren't orphans.
- `vault/README.md`: schema contract table so consumers know what the linter will check.

## Test plan

- [x] `node index.js lint --vault vault` → `✓ No issues found.`
- [x] `node test/retrieval/eval.js` → recall@5 unchanged (64.3% / MRR 0.559), no regression.
- [x] `gotchas.md` — intentionally stripping a `**Fix**` label produces `missing-bold-label`; intentionally removing a glossary `terms` entry produces `missing-glossary-term-section` (local spot-checks).
- [x] Schemas not in table (overview/architecture/research) remain free-form — no false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)