### PR TITLE
feat: vault_create_note + vault_write MCP tools (#22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd web && npm install && cd ..
 
       - name: Type check (CLI)
-        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js
+        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js
 
       - name: Type check (web)
         run: cd web && npx tsc --noEmit && cd ..
@@ -52,6 +52,9 @@ jobs:
 
       - name: Status-aware retrieval assertions
         run: node test/retrieval/status_filter.test.js
+
+      - name: Vault write-back assertions
+        run: node test/vault-write.test.js
 
       - name: Lint web (if eslintrc exists)
         run: cd web && npm run lint 2>/dev/null || echo "No lint script defined"

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -7,6 +7,7 @@ import fsSync from "fs";
 import path from "path";
 import { Vault } from "./vault.js";
 import { lintVault } from "./linter.js";
+import { createNote, writeNote } from "./vault-write.js";
 
 const vaultDir = process.env.VAULT_DIR || "./vault";
 const vault = new Vault(vaultDir);
@@ -390,6 +391,63 @@ if (embeddingsDb) {
     })
   );
 }
+
+async function resyncAfterWrite() {
+  await vault.reindex();
+  if (embeddingsDb && syncEmbeddings) {
+    try {
+      await syncEmbeddings(embeddingsDb, vault);
+    } catch (e) {
+      console.error("post-write embedding sync failed:", e);
+    }
+  }
+}
+
+server.registerTool(
+  "vault_create_note",
+  {
+    description:
+      "Create a new vault note. Fails if the id already exists, if required fields are missing, or if the body contains unresolved wiki-links (`[[target]]` where `target` is not an existing note id). Frontmatter is built from the provided fields; `date` and `lastVerified` default to today. After writing, the vault is reindexed and embeddings are synced so the new note is immediately searchable. Returns the created note as read back from disk. Use this to author new notes from an agent workflow; use vault_write to edit an existing note.",
+    inputSchema: {
+      id: z.string(),
+      type: z.string(),
+      title: z.string(),
+      body: z.string(),
+      tags: z.array(z.string()).optional(),
+      description: z.string().optional(),
+      summary: z.string().optional(),
+      status: z.enum(["draft", "current", "stale", "deprecated"]).optional(),
+    },
+  },
+  safe(async (params) => {
+    const result = await createNote(vault, params);
+    await resyncAfterWrite();
+    const note = await vault.getNote(result.id);
+    return {
+      content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+    };
+  })
+);
+
+server.registerTool(
+  "vault_write",
+  {
+    description:
+      "Update an existing vault note. `content` may be either (a) full markdown with a leading `---` frontmatter block — frontmatter is merge-patched over the existing file's frontmatter (new keys win, untouched keys preserved) and body is replaced; or (b) body-only markdown (no leading frontmatter) — existing frontmatter is preserved verbatim and only the body is replaced. Fails if the note does not exist (use vault_create_note), if the body is empty, or if the body introduces unresolved wiki-links. After writing, the vault is reindexed and embeddings are synced. Returns the updated note as read back from disk.",
+    inputSchema: {
+      id: z.string(),
+      content: z.string(),
+    },
+  },
+  safe(async ({ id, content }) => {
+    const result = await writeNote(vault, id, content);
+    await resyncAfterWrite();
+    const note = await vault.getNote(result.id);
+    return {
+      content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+    };
+  })
+);
 
 const shutdown = async () => {
   await watcher.close();

--- a/lib/vault-write.js
+++ b/lib/vault-write.js
@@ -1,0 +1,269 @@
+import fs from "fs/promises";
+import path from "path";
+
+/**
+ * Write-back primitives (#22).
+ *
+ * Both functions take a reindexed Vault (for validation context), write the
+ * target file atomically, and return { id, path, content }. Callers are
+ * responsible for reindexing afterwards — keeping write and index concerns
+ * separated so MCP can drive embedding resync while the CLI stays simple.
+ */
+
+const FM_ARRAY_KEYS = new Set(["tags", "terms"]);
+const FM_FIELD_ORDER = [
+  "title",
+  "type",
+  "status",
+  "date",
+  "lastVerified",
+  "description",
+  "summary",
+  "tags",
+  "terms",
+];
+const VALID_STATUSES = new Set(["draft", "current", "stale", "deprecated"]);
+
+function splitFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return { frontmatter: null, body: content };
+  return { frontmatter: match[1], body: match[2] };
+}
+
+function parseFrontmatterBlock(yaml) {
+  const fm = {};
+  for (const line of yaml.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx <= 0) continue;
+    const k = line.slice(0, colonIdx).trim();
+    const v = line.slice(colonIdx + 1).trim();
+    if (!k) continue;
+    if (FM_ARRAY_KEYS.has(k)) {
+      const m = v.match(/\[(.*?)\]/);
+      fm[k] = m ? m[1].split(",").map((s) => s.trim()).filter(Boolean) : [];
+    } else {
+      fm[k] = v.replace(/^["']|["']$/g, "");
+    }
+  }
+  return fm;
+}
+
+function serializeField(k, v) {
+  if (FM_ARRAY_KEYS.has(k)) {
+    const arr = Array.isArray(v) ? v : [];
+    return `${k}: [${arr.join(", ")}]`;
+  }
+  const s = String(v);
+  // Quote strings containing YAML-significant chars so the parser round-trips.
+  const needsQuote = /[:#]/.test(s) || /^\s|\s$/.test(s);
+  return `${k}: ${needsQuote ? `"${s.replace(/"/g, '\\"')}"` : s}`;
+}
+
+function serializeFrontmatter(fm) {
+  const lines = [];
+  const seen = new Set();
+  for (const k of FM_FIELD_ORDER) {
+    if (fm[k] == null || fm[k] === "") continue;
+    seen.add(k);
+    lines.push(serializeField(k, fm[k]));
+  }
+  for (const k of Object.keys(fm)) {
+    if (seen.has(k) || fm[k] == null || fm[k] === "") continue;
+    lines.push(serializeField(k, fm[k]));
+  }
+  return lines.join("\n");
+}
+
+function validateId(id) {
+  if (!id || typeof id !== "string") throw new Error("id is required");
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9/_-]*$/.test(id)) {
+    throw new Error(
+      `id must match [a-zA-Z0-9/_-] and start with alphanumeric: ${id}`
+    );
+  }
+  if (id.includes("..")) throw new Error(`id cannot contain '..': ${id}`);
+}
+
+function resolveInsideVault(vaultDir, id) {
+  const vaultAbs = path.resolve(vaultDir);
+  const fileAbs = path.resolve(path.join(vaultAbs, `${id}.md`));
+  if (fileAbs !== vaultAbs && !fileAbs.startsWith(vaultAbs + path.sep)) {
+    throw new Error(`Resolved path escapes vault: ${id}`);
+  }
+  return fileAbs;
+}
+
+/**
+ * Collect wiki-link targets outside code fences/spans — mirrors vault.js.
+ */
+function extractWikiTargets(body) {
+  const stripped = body
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`\n]*`/g, "");
+  const matches = stripped.match(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g) || [];
+  return matches
+    .map((m) => m.replace(/\[\[([^\]|]+).*\]\]/, "$1").trim())
+    .filter(Boolean);
+}
+
+function findDeadLinks(vault, body, selfId = null) {
+  const noteIds = new Set(vault.index.map((n) => n.id));
+  if (selfId) noteIds.add(selfId);
+  const dead = [];
+  for (const target of extractWikiTargets(body)) {
+    if (!noteIds.has(target)) dead.push(target);
+  }
+  return [...new Set(dead)];
+}
+
+async function atomicWrite(filePath, content) {
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    await fs.writeFile(tmp, content, "utf-8");
+    await fs.rename(tmp, filePath);
+  } catch (err) {
+    try {
+      await fs.unlink(tmp);
+    } catch {
+      // best-effort cleanup
+    }
+    throw err;
+  }
+}
+
+/**
+ * Create a new note. Fails on id collision, missing required fields, or
+ * unresolved wiki-links in the body.
+ *
+ * Returns { id, path, content }. Caller reindexes and re-reads as needed.
+ */
+export async function createNote(vault, params) {
+  const {
+    id,
+    type,
+    title,
+    body,
+    tags = [],
+    description = "",
+    summary = "",
+    status = "current",
+  } = params || {};
+
+  validateId(id);
+  if (!type) throw new Error("type is required");
+  if (!title) throw new Error("title is required");
+  if (typeof body !== "string" || !body.trim()) {
+    throw new Error("body is required");
+  }
+  if (!VALID_STATUSES.has(status)) {
+    throw new Error(
+      `status must be one of ${[...VALID_STATUSES].join(", ")}: got "${status}"`
+    );
+  }
+
+  const filePath = resolveInsideVault(vault.vaultDir, id);
+
+  let exists = false;
+  try {
+    await fs.stat(filePath);
+    exists = true;
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+  if (exists) throw new Error(`Note already exists: ${id}`);
+
+  const dead = findDeadLinks(vault, body, id);
+  if (dead.length > 0) {
+    throw new Error(
+      `Body has unresolved wiki-links: ${dead.join(", ")}. Create targets first, or fix the reference.`
+    );
+  }
+
+  const today = new Date().toISOString().split("T")[0];
+  const fm = {
+    title,
+    type,
+    status,
+    date: today,
+    lastVerified: today,
+    description,
+    summary,
+    tags,
+  };
+
+  const content = `---\n${serializeFrontmatter(fm)}\n---\n\n${body.trim()}\n`;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await atomicWrite(filePath, content);
+
+  return { id, path: path.relative(vault.vaultDir, filePath), content };
+}
+
+/**
+ * Update an existing note. Content may be either:
+ *
+ *   1. Full markdown with a leading `---` frontmatter block. Frontmatter
+ *      is merge-patched over the existing file's frontmatter (new keys win
+ *      on overlap; untouched keys are preserved). Body is replaced.
+ *
+ *   2. Body-only markdown (no leading frontmatter block). Existing
+ *      frontmatter is preserved verbatim; body is replaced.
+ *
+ * Fails if the note doesn't exist (use createNote) or the body introduces
+ * unresolved wiki-links.
+ */
+export async function writeNote(vault, id, content) {
+  validateId(id);
+  if (typeof content !== "string") throw new Error("content must be a string");
+
+  const filePath = resolveInsideVault(vault.vaultDir, id);
+
+  let existing;
+  try {
+    existing = await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      throw new Error(`Note not found: ${id} (use createNote to create it)`);
+    }
+    throw err;
+  }
+
+  const existingSplit = splitFrontmatter(existing);
+  const existingFm = existingSplit.frontmatter
+    ? parseFrontmatterBlock(existingSplit.frontmatter)
+    : {};
+
+  const incoming = splitFrontmatter(content);
+  let mergedFm;
+  let body;
+  if (incoming.frontmatter !== null) {
+    const patch = parseFrontmatterBlock(incoming.frontmatter);
+    mergedFm = { ...existingFm, ...patch };
+    body = incoming.body;
+  } else {
+    mergedFm = existingFm;
+    body = content;
+  }
+  body = body.trim();
+  if (!body) throw new Error("body cannot be empty");
+
+  const dead = findDeadLinks(vault, body, id);
+  if (dead.length > 0) {
+    throw new Error(
+      `Body has unresolved wiki-links: ${dead.join(", ")}. Create targets first, or fix the reference.`
+    );
+  }
+
+  const newContent = `---\n${serializeFrontmatter(mergedFm)}\n---\n\n${body}\n`;
+  await atomicWrite(filePath, newContent);
+
+  return { id, path: path.relative(vault.vaultDir, filePath), content: newContent };
+}
+
+// Exported for testing.
+export const __test = {
+  splitFrontmatter,
+  parseFrontmatterBlock,
+  serializeFrontmatter,
+  validateId,
+  extractWikiTargets,
+};

--- a/test/vault-write.test.js
+++ b/test/vault-write.test.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Write-back assertions — issue #22.
+ *
+ * Exercises createNote + writeNote against a throwaway vault on disk:
+ *   - happy path create + round-trip through Vault.reindex()
+ *   - id collision, missing required fields, dead wiki-links, path escape
+ *   - writeNote preserves frontmatter on body-only input
+ *   - writeNote merge-patches frontmatter on full-markdown input
+ *   - writeNote rejects non-existent ids
+ *   - atomic write leaves no .tmp-* turds on success
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Vault } from "../lib/vault.js";
+import { createNote, writeNote, __test } from "../lib/vault-write.js";
+
+const FIXTURE = path.join(os.tmpdir(), `vault-write-fixture-${process.pid}`);
+
+function setupFixture() {
+  if (fs.existsSync(FIXTURE)) fs.rmSync(FIXTURE, { recursive: true, force: true });
+  fs.mkdirSync(path.join(FIXTURE, "demo"), { recursive: true });
+  // Seed one existing note so we have an id to link to and to overwrite.
+  const seed = `---
+title: Seed note
+type: overview
+status: current
+date: 2026-01-01
+lastVerified: 2026-04-20
+description: Pre-existing note used as link target
+tags: [seed, demo]
+---
+
+# Seed note
+
+Some seed content to link against from later notes.
+`;
+  fs.writeFileSync(path.join(FIXTURE, "demo", "seed.md"), seed);
+}
+
+function teardown() {
+  try { fs.rmSync(FIXTURE, { recursive: true, force: true }); } catch {}
+}
+
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    process.stderr.write(`  ✓ ${msg}\n`);
+  } else {
+    failed++;
+    process.stderr.write(`  ✗ ${msg}\n`);
+  }
+}
+
+async function expectThrow(fn, matcher, msg) {
+  try {
+    await fn();
+  } catch (err) {
+    const m = typeof matcher === "string" ? err.message.includes(matcher) : matcher.test(err.message);
+    assert(m, `${msg} (got: ${err.message})`);
+    return;
+  }
+  assert(false, `${msg} (no error thrown)`);
+}
+
+async function main() {
+  setupFixture();
+  const vault = new Vault(FIXTURE);
+  await vault.reindex();
+
+  process.stderr.write("createNote happy path\n");
+  const created = await createNote(vault, {
+    id: "demo/new-feature",
+    type: "feature",
+    title: "New feature",
+    body: "## What\n\nA new feature.\n\n## Why\n\nBecause.\n\n## How\n\nLike [[demo/seed]].\n",
+    tags: ["demo", "new"],
+    description: "One-line description",
+    summary: "Summary TL;DR",
+  });
+  assert(created.id === "demo/new-feature", "returns id");
+  assert(fs.existsSync(path.join(FIXTURE, "demo", "new-feature.md")), "file written to disk");
+  const createdContent = fs.readFileSync(path.join(FIXTURE, "demo", "new-feature.md"), "utf-8");
+  assert(createdContent.startsWith("---\n"), "has frontmatter block");
+  assert(createdContent.includes("type: feature"), "type serialized");
+  assert(createdContent.includes("status: current"), "status defaults to current");
+  assert(/date: \d{4}-\d{2}-\d{2}/.test(createdContent), "date stamped");
+  assert(/lastVerified: \d{4}-\d{2}-\d{2}/.test(createdContent), "lastVerified stamped");
+  assert(createdContent.includes("tags: [demo, new]"), "tags array serialized");
+
+  // Vault indexes the new note correctly.
+  await vault.reindex();
+  const reread = vault.index.find((n) => n.id === "demo/new-feature");
+  assert(reread && reread.title === "New feature", "vault reindex picks up the new note");
+  assert(reread && reread.status === "current", "indexed status is current");
+  assert(reread && reread.type === "feature", "indexed type is feature");
+
+  process.stderr.write("\ncreateNote rejections\n");
+  await expectThrow(
+    () => createNote(vault, { id: "demo/new-feature", type: "feature", title: "dup", body: "hi" }),
+    "already exists",
+    "rejects id collision"
+  );
+  await expectThrow(
+    () => createNote(vault, { id: "demo/no-title", type: "feature", body: "hi" }),
+    "title is required",
+    "rejects missing title"
+  );
+  await expectThrow(
+    () => createNote(vault, { id: "demo/no-type", title: "x", body: "hi" }),
+    "type is required",
+    "rejects missing type"
+  );
+  await expectThrow(
+    () => createNote(vault, { id: "demo/no-body", type: "feature", title: "x" }),
+    "body is required",
+    "rejects missing body"
+  );
+  await expectThrow(
+    () =>
+      createNote(vault, {
+        id: "demo/bad-link",
+        type: "feature",
+        title: "x",
+        body: "## What\n\nLink to [[demo/does-not-exist]].\n",
+      }),
+    "unresolved wiki-links",
+    "rejects unresolved wiki-links"
+  );
+  await expectThrow(
+    () =>
+      createNote(vault, {
+        id: "../escape",
+        type: "feature",
+        title: "x",
+        body: "body",
+      }),
+    /id must match|cannot contain '\.\.'|escapes vault/,
+    "rejects path escape"
+  );
+  await expectThrow(
+    () =>
+      createNote(vault, {
+        id: "demo/bad-status",
+        type: "feature",
+        title: "x",
+        body: "body",
+        status: "nonsense",
+      }),
+    "status must be one of",
+    "rejects unknown status"
+  );
+
+  process.stderr.write("\nwriteNote body-only preserves frontmatter\n");
+  const bodyOnlyRes = await writeNote(
+    vault,
+    "demo/new-feature",
+    "## What\n\nUpdated body only.\n\n## Why\n\nRefreshed.\n\n## How\n\nStill references [[demo/seed]].\n"
+  );
+  assert(bodyOnlyRes.content.includes("type: feature"), "body-only preserves type");
+  assert(bodyOnlyRes.content.includes("tags: [demo, new]"), "body-only preserves tags");
+  assert(bodyOnlyRes.content.includes("Updated body only"), "body replaced");
+  assert(bodyOnlyRes.content.includes("description: One-line description"), "body-only preserves description");
+
+  process.stderr.write("\nwriteNote full-markdown merges frontmatter\n");
+  const fullMdRes = await writeNote(
+    vault,
+    "demo/new-feature",
+    `---
+status: stale
+summary: New summary
+---
+
+## What
+
+Merge-patched frontmatter.
+
+## Why
+
+Because.
+
+## How
+
+See [[demo/seed]].
+`
+  );
+  assert(fullMdRes.content.includes("status: stale"), "status patched");
+  assert(fullMdRes.content.includes("summary: New summary"), "summary patched");
+  assert(fullMdRes.content.includes("type: feature"), "unchanged type preserved");
+  assert(fullMdRes.content.includes("tags: [demo, new]"), "unchanged tags preserved");
+  assert(fullMdRes.content.includes("Merge-patched frontmatter"), "body replaced");
+
+  process.stderr.write("\nwriteNote rejections\n");
+  await expectThrow(
+    () => writeNote(vault, "demo/does-not-exist", "body"),
+    "Note not found",
+    "rejects missing note"
+  );
+  await expectThrow(
+    () => writeNote(vault, "demo/new-feature", "Body with [[demo/ghost]] link.\n"),
+    "unresolved wiki-links",
+    "rejects unresolved wiki-links on update"
+  );
+  await expectThrow(
+    () => writeNote(vault, "demo/new-feature", "   \n   \n"),
+    "body cannot be empty",
+    "rejects empty body"
+  );
+
+  process.stderr.write("\nAtomic write cleanup\n");
+  const leftovers = fs
+    .readdirSync(path.join(FIXTURE, "demo"))
+    .filter((f) => f.includes(".tmp-"));
+  assert(leftovers.length === 0, `no .tmp-* files left behind (found: ${leftovers.join(", ")})`);
+
+  process.stderr.write("\nvalidateId unit checks\n");
+  const { validateId } = __test;
+  assert.throws = () => {};
+  try { validateId("demo/good_id-1"); assert(true, "accepts valid id"); }
+  catch (e) { assert(false, `should accept valid id: ${e.message}`); }
+  try { validateId("has space"); assert(false, "should reject space"); }
+  catch { assert(true, "rejects id with space"); }
+  try { validateId(""); assert(false, "should reject empty"); }
+  catch { assert(true, "rejects empty id"); }
+  try { validateId("foo/../bar"); assert(false, "should reject .."); }
+  catch { assert(true, "rejects id with .."); }
+
+  teardown();
+  if (failed > 0) {
+    process.stderr.write(`\n✗ ${failed} assertion(s) failed\n`);
+    process.exit(1);
+  }
+  process.stderr.write("\n✓ All vault-write assertions passed.\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  teardown();
+  process.exit(1);
+});

--- a/vault/README.md
+++ b/vault/README.md
@@ -109,6 +109,17 @@ Scaffold a new note with the right shape via `claude-code-vault add <path> "<tit
 
 Types not in the table above warn as `unknown-type`. See [[claude-code-vault/gotchas/gotchas]] for the full enum.
 
+## Write-back MCP tools
+
+Agents can author notes directly through two MCP tools (the CLI does not currently wrap them — use MCP):
+
+- **`vault_create_note`** — create a new note. Required: `id`, `type`, `title`, `body`. Optional: `tags`, `description`, `summary`, `status` (defaults to `current`). Fails on id collision, missing required fields, unknown status, or unresolved wiki-links in the body. `date` and `lastVerified` are stamped to today.
+- **`vault_write`** — update an existing note. `content` may be either full markdown with a leading `---` frontmatter block (merge-patched over existing frontmatter; body replaced) or body-only markdown (existing frontmatter preserved; body replaced). Fails if the note doesn't exist, the body is empty, or the body introduces unresolved wiki-links.
+
+Both tools write atomically (tmp-file + rename), then reindex the vault and resync embeddings so the write is immediately searchable. Both return the note as read back from disk.
+
+Use these to keep agent-authored content subject to the same schema and link-integrity rules as hand-written notes.
+
 ## Starting a new project
 
 1. `mkdir vault/new-project/`


### PR DESCRIPTION
Closes #22.

## Summary
- New `lib/vault-write.js` with `createNote` + `writeNote` primitives: id/path validation, required-field checks, dead-wiki-link detection, atomic tmp+rename write, frontmatter merge-patch.
- Two new MCP tools — `vault_create_note` (collision-rejecting create) and `vault_write` (update that accepts full markdown for frontmatter merge, or body-only to preserve frontmatter). Both trigger an immediate reindex + embedding resync.
- 35-assertion test suite covering happy path, every rejection case, frontmatter-preserve vs merge-patch semantics, and atomic-write cleanup.
- README docs + CI wiring.

Retrieval eval unchanged at recall@5 = 64.3% / MRR = 0.559.

## Test plan
- [x] `node test/vault-write.test.js` — 35/35 pass
- [x] `npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/**/*.js` — clean
- [x] `node index.js lint --vault vault` — no issues
- [x] `node test/retrieval/eval.js` — no retrieval regression
- [ ] CI green on `feat/vault-write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)