### PR TITLE
feat: vault_append_section + vault_replace_section MCP tools (#23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd web && npm install && cd ..
 
       - name: Type check (CLI)
-        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js
+        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js test/section-edit.test.js
 
       - name: Type check (web)
         run: cd web && npx tsc --noEmit && cd ..
@@ -55,6 +55,9 @@ jobs:
 
       - name: Vault write-back assertions
         run: node test/vault-write.test.js
+
+      - name: Section-edit assertions
+        run: node test/section-edit.test.js
 
       - name: Lint web (if eslintrc exists)
         run: cd web && npm run lint 2>/dev/null || echo "No lint script defined"

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -7,7 +7,7 @@ import fsSync from "fs";
 import path from "path";
 import { Vault } from "./vault.js";
 import { lintVault } from "./linter.js";
-import { createNote, writeNote } from "./vault-write.js";
+import { createNote, writeNote, editSection } from "./vault-write.js";
 
 const vaultDir = process.env.VAULT_DIR || "./vault";
 const vault = new Vault(vaultDir);
@@ -441,6 +441,48 @@ server.registerTool(
   },
   safe(async ({ id, content }) => {
     const result = await writeNote(vault, id, content);
+    await resyncAfterWrite();
+    const note = await vault.getNote(result.id);
+    return {
+      content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+    };
+  })
+);
+
+server.registerTool(
+  "vault_append_section",
+  {
+    description:
+      "Append `content` to a single heading-section of an existing note, identified by `headingPath` — a strict ancestor chain of heading texts (e.g. `[\"Gotchas\", \"Auth retry storm\"]` for an H2 \"Auth retry storm\" nested directly under H1 \"Gotchas\"). The new content lands after the section's last non-blank body line, before the next same-or-higher heading. The heading line itself is never modified, frontmatter is left untouched. Fails if the path matches zero or multiple sections, or if the resulting body has unresolved wiki-links. After writing, the vault is reindexed and embeddings are synced. Use this for low-overhead incremental updates (e.g. adding a single gotcha) instead of round-tripping the whole note through vault_write.",
+    inputSchema: {
+      id: z.string(),
+      headingPath: z.array(z.string()).min(1),
+      content: z.string(),
+    },
+  },
+  safe(async ({ id, headingPath, content }) => {
+    const result = await editSection(vault, id, "append", headingPath, content);
+    await resyncAfterWrite();
+    const note = await vault.getNote(result.id);
+    return {
+      content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+    };
+  })
+);
+
+server.registerTool(
+  "vault_replace_section",
+  {
+    description:
+      "Replace the body of a single heading-section. `headingPath` selects the section under strict-ancestor-chain semantics (see vault_append_section). The heading line is preserved verbatim; everything between it and the next same-or-higher heading — including any nested subsections — is replaced with `content`. Pass an empty `content` to clear the section body. Frontmatter is untouched. Fails on path miss, ambiguous match, or unresolved wiki-links in the result. After writing, the vault is reindexed and embeddings are synced.",
+    inputSchema: {
+      id: z.string(),
+      headingPath: z.array(z.string()).min(1),
+      content: z.string(),
+    },
+  },
+  safe(async ({ id, headingPath, content }) => {
+    const result = await editSection(vault, id, "replace", headingPath, content);
     await resyncAfterWrite();
     const note = await vault.getNote(result.id);
     return {

--- a/lib/sections.js
+++ b/lib/sections.js
@@ -1,0 +1,193 @@
+/**
+ * Line-preserving heading tree for section-level edits (#23).
+ *
+ * Distinct from chunks.js: chunks.js is shaped for retrieval (merges short
+ * sections together, splits oversized ones, drops empty ones). For surgical
+ * edits we need every heading boundary preserved verbatim with the exact
+ * source line ranges. Mixing the two would mean either retrieval loses
+ * locality or edits lose precision.
+ */
+
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
+const FENCE_RE = /^```/;
+const FRONTMATTER_RE = /^---\n[\s\S]*?\n---\n?/;
+
+/**
+ * Locate the frontmatter block (if any) and return { fmEnd, bodyStartLine }.
+ * fmEnd is the byte offset where frontmatter ends; bodyStartLine is the
+ * 0-indexed line in the original file at which the body begins.
+ */
+export function findFrontmatter(content) {
+  const m = content.match(FRONTMATTER_RE);
+  if (!m) return { fmEnd: 0, bodyStartLine: 0 };
+  const fmText = m[0];
+  return { fmEnd: fmText.length, bodyStartLine: fmText.split("\n").length - 1 };
+}
+
+/**
+ * Parse the body of a markdown file into a flat list of section records.
+ * Each record describes a heading and the half-open line range [bodyStart,
+ * bodyEnd) of its body — the lines after the heading up to (but not
+ * including) the next same-or-higher heading.
+ *
+ * Lines inside fenced code blocks that look like headings are ignored.
+ *
+ * Line numbers are 0-indexed against `bodyLines`. Callers translate back
+ * to file lines by adding `bodyStartLine`.
+ *
+ * Returns: [{ level, text, headingLine, bodyStart, bodyEnd, ancestors }]
+ *   - level: 1-6
+ *   - text: heading text after the `#` markers, trimmed
+ *   - headingLine: line index of the `#` line
+ *   - bodyStart: line index of the first body line (== headingLine + 1)
+ *   - bodyEnd: exclusive end of body region (start of next same-or-higher
+ *     heading, or bodyLines.length if last)
+ *   - ancestors: array of parent heading texts (root → immediate parent)
+ */
+export function parseSections(bodyLines) {
+  const sections = [];
+  const stack = [];
+  let inFence = false;
+
+  for (let i = 0; i < bodyLines.length; i++) {
+    const line = bodyLines[i];
+    if (FENCE_RE.test(line.trimStart())) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const h = line.match(HEADING_RE);
+    if (!h) continue;
+    const level = h[1].length;
+    const text = h[2].trim();
+
+    while (stack.length && stack[stack.length - 1].level >= level) stack.pop();
+    const ancestors = stack.map((s) => s.text);
+
+    const section = {
+      level,
+      text,
+      headingLine: i,
+      bodyStart: i + 1,
+      bodyEnd: bodyLines.length,
+      ancestors,
+    };
+    sections.push(section);
+    stack.push(section);
+  }
+
+  // Second pass: close out bodyEnd at the next same-or-higher heading.
+  for (let i = 0; i < sections.length; i++) {
+    for (let j = i + 1; j < sections.length; j++) {
+      if (sections[j].level <= sections[i].level) {
+        sections[i].bodyEnd = sections[j].headingLine;
+        break;
+      }
+    }
+  }
+
+  return sections;
+}
+
+/**
+ * Find the unique section matching headingPath under strict-ancestor-chain
+ * semantics. `["A", "B"]` means: a heading "B" whose immediate parent in
+ * the heading hierarchy is "A". Empty path is rejected by the caller.
+ *
+ * Throws if the path matches zero sections (with the closest near-misses
+ * surfaced) or more than one (ambiguity — caller must disambiguate).
+ */
+export function findSection(sections, headingPath) {
+  if (!Array.isArray(headingPath) || headingPath.length === 0) {
+    throw new Error("headingPath must be a non-empty array of heading texts");
+  }
+  for (const part of headingPath) {
+    if (typeof part !== "string" || !part.trim()) {
+      throw new Error("headingPath entries must be non-empty strings");
+    }
+  }
+  const target = headingPath[headingPath.length - 1].trim();
+  const expectedAncestors = headingPath.slice(0, -1).map((s) => s.trim());
+
+  const matches = sections.filter((s) => {
+    if (s.text !== target) return false;
+    if (s.ancestors.length !== expectedAncestors.length) return false;
+    for (let i = 0; i < expectedAncestors.length; i++) {
+      if (s.ancestors[i] !== expectedAncestors[i]) return false;
+    }
+    return true;
+  });
+
+  if (matches.length === 0) {
+    const breadcrumbs = sections.map((s) => [...s.ancestors, s.text].join(" > "));
+    throw new Error(
+      `headingPath not found: ${headingPath.join(" > ")}. Available headings: ${
+        breadcrumbs.length ? breadcrumbs.join("; ") : "(none)"
+      }`
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `headingPath is ambiguous: ${headingPath.join(" > ")} matches ${
+        matches.length
+      } sections at lines ${matches.map((m) => m.headingLine).join(", ")}. Disambiguate by extending the path.`
+    );
+  }
+  return matches[0];
+}
+
+/**
+ * Apply an append: insert `addition` after the section's last non-blank
+ * body line, separated by a blank line, before the next same-or-higher
+ * heading. Returns the new bodyLines array.
+ */
+export function appendToSectionLines(bodyLines, section, addition) {
+  const additionLines = String(addition).replace(/\s+$/, "").split("\n");
+  // Find the last non-blank line in the body region.
+  let insertAt = section.bodyEnd; // default: just before next heading
+  for (let i = section.bodyEnd - 1; i >= section.bodyStart; i--) {
+    if (bodyLines[i].trim() !== "") {
+      insertAt = i + 1;
+      break;
+    }
+  }
+  // Build the splice payload: blank-line separator (if needed) + content +
+  // trailing blank if there's something after.
+  const payload = [];
+  const prevLine = insertAt > 0 ? bodyLines[insertAt - 1] : "";
+  if (prevLine.trim() !== "") payload.push("");
+  payload.push(...additionLines);
+  // Ensure a blank line between our addition and the next section (if any).
+  const nextLine = bodyLines[insertAt];
+  if (nextLine !== undefined && nextLine.trim() !== "") payload.push("");
+
+  const out = bodyLines.slice();
+  out.splice(insertAt, 0, ...payload);
+  return out;
+}
+
+/**
+ * Apply a replace: swap the entire body region (after the heading line up
+ * to the next same-or-higher heading) with `replacement`. The heading line
+ * itself is preserved verbatim. Returns the new bodyLines array.
+ */
+export function replaceSectionLines(bodyLines, section, replacement) {
+  const replacementText = String(replacement).replace(/^\s+|\s+$/g, "");
+  const replacementLines = replacementText === "" ? [] : replacementText.split("\n");
+  // Build the body slot: blank line after heading, the content, blank line
+  // before next heading. Empty replacement just collapses to a single blank
+  // line so the heading isn't glued to the next one.
+  const slot = [];
+  if (replacementLines.length > 0) {
+    slot.push("");
+    slot.push(...replacementLines);
+    if (section.bodyEnd < bodyLines.length) slot.push("");
+  } else {
+    slot.push("");
+  }
+  const out = bodyLines.slice();
+  out.splice(section.bodyStart, section.bodyEnd - section.bodyStart, ...slot);
+  return out;
+}
+
+export const __test = { HEADING_RE, FENCE_RE };

--- a/lib/vault-write.js
+++ b/lib/vault-write.js
@@ -1,5 +1,12 @@
 import fs from "fs/promises";
 import path from "path";
+import {
+  findFrontmatter,
+  parseSections,
+  findSection,
+  appendToSectionLines,
+  replaceSectionLines,
+} from "./sections.js";
 
 /**
  * Write-back primitives (#22).
@@ -254,6 +261,68 @@ export async function writeNote(vault, id, content) {
   }
 
   const newContent = `---\n${serializeFrontmatter(mergedFm)}\n---\n\n${body}\n`;
+  await atomicWrite(filePath, newContent);
+
+  return { id, path: path.relative(vault.vaultDir, filePath), content: newContent };
+}
+
+/**
+ * Edit a single heading-section of an existing note. `mode` is "append" or
+ * "replace". headingPath is a strict ancestor chain (see sections.js). The
+ * heading line itself is never modified; frontmatter is left untouched.
+ *
+ * Fails if the note doesn't exist, the path doesn't match (or matches more
+ * than one section), or the resulting body introduces unresolved wiki-links.
+ */
+export async function editSection(vault, id, mode, headingPath, content) {
+  if (mode !== "append" && mode !== "replace") {
+    throw new Error(`mode must be "append" or "replace", got ${mode}`);
+  }
+  validateId(id);
+  if (typeof content !== "string") throw new Error("content must be a string");
+  if (mode === "append" && content.trim() === "") {
+    throw new Error("content cannot be empty for append");
+  }
+
+  const filePath = resolveInsideVault(vault.vaultDir, id);
+
+  let existing;
+  try {
+    existing = await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      throw new Error(`Note not found: ${id} (use createNote to create it)`);
+    }
+    throw err;
+  }
+
+  const { fmEnd } = findFrontmatter(existing);
+  const fmText = existing.slice(0, fmEnd);
+  const bodyText = existing.slice(fmEnd);
+  const trailingNewline = bodyText.endsWith("\n");
+  const bodyLines = bodyText.replace(/\n$/, "").split("\n");
+
+  const sections = parseSections(bodyLines);
+  const section = findSection(sections, headingPath);
+
+  const updatedLines =
+    mode === "append"
+      ? appendToSectionLines(bodyLines, section, content)
+      : replaceSectionLines(bodyLines, section, content);
+
+  let updatedBody = updatedLines.join("\n");
+  if (trailingNewline && !updatedBody.endsWith("\n")) updatedBody += "\n";
+
+  const dead = findDeadLinks(vault, updatedBody, id);
+  if (dead.length > 0) {
+    throw new Error(
+      `Body has unresolved wiki-links after edit: ${dead.join(
+        ", "
+      )}. Create targets first, or fix the reference.`
+    );
+  }
+
+  const newContent = fmText + updatedBody;
   await atomicWrite(filePath, newContent);
 
   return { id, path: path.relative(vault.vaultDir, filePath), content: newContent };

--- a/test/section-edit.test.js
+++ b/test/section-edit.test.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * Section-level edit assertions — issue #23.
+ *
+ * Builds a throwaway vault with a multi-heading note, then exercises
+ * editSection (append + replace) directly. Covers happy paths, path
+ * resolution edge cases, ambiguity handling, frontmatter preservation,
+ * subsection wipe semantics, and dead-link rejection.
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Vault } from "../lib/vault.js";
+import { editSection } from "../lib/vault-write.js";
+import { parseSections, findSection } from "../lib/sections.js";
+
+const FIXTURE = path.join(os.tmpdir(), `vault-section-fixture-${process.pid}`);
+
+const SAMPLE = `---
+title: Gotchas
+type: gotcha
+status: current
+date: 2026-01-01
+lastVerified: 2026-04-20
+description: Demo gotcha note for section-edit tests
+tags: [demo, gotcha]
+---
+
+# Gotchas
+
+Intro paragraph.
+
+## Auth retry storm
+
+**Symptom**: clients hammer the auth endpoint.
+
+**Cause**: missing exponential backoff.
+
+**Fix**: add jitter.
+
+### Verify
+
+Run \`./scripts/check-backoff.sh\`.
+
+## Cache stampede
+
+**Symptom**: thundering herd on cache miss.
+
+**Cause**: no request coalescing.
+
+**Fix**: single-flight wrapper.
+
+# Appendix
+
+Trailing notes here.
+`;
+
+function setupFixture() {
+  if (fs.existsSync(FIXTURE)) fs.rmSync(FIXTURE, { recursive: true, force: true });
+  fs.mkdirSync(path.join(FIXTURE, "demo"), { recursive: true });
+  fs.writeFileSync(path.join(FIXTURE, "demo", "gotchas.md"), SAMPLE);
+  // Seed a second note that exists as a wiki-link target.
+  fs.writeFileSync(
+    path.join(FIXTURE, "demo", "seed.md"),
+    `---\ntitle: Seed\ntype: overview\nstatus: current\ndate: 2026-01-01\ntags: [seed]\n---\n\n# Seed\n\nLinkable.\n`
+  );
+}
+
+function teardown() {
+  try { fs.rmSync(FIXTURE, { recursive: true, force: true }); } catch {}
+}
+
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) {
+    process.stderr.write(`  ✓ ${msg}\n`);
+  } else {
+    failed++;
+    process.stderr.write(`  ✗ ${msg}\n`);
+  }
+}
+
+async function expectThrow(fn, matcher, msg) {
+  try {
+    await fn();
+  } catch (err) {
+    const ok = typeof matcher === "string" ? err.message.includes(matcher) : matcher.test(err.message);
+    assert(ok, `${msg} (got: ${err.message})`);
+    return;
+  }
+  assert(false, `${msg} (no error thrown)`);
+}
+
+async function main() {
+  setupFixture();
+  const vault = new Vault(FIXTURE);
+  await vault.reindex();
+
+  process.stderr.write("parseSections + findSection unit checks\n");
+  const bodyLines = SAMPLE.split(/\n---\n/).slice(2).join("\n---\n").split("\n");
+  // Simpler: re-parse via the same pathway editSection uses.
+  const lines = SAMPLE.split("\n");
+  const fmEnd = lines.findIndex((l, i) => i > 0 && l === "---") + 1;
+  const sections = parseSections(lines.slice(fmEnd));
+  const breadcrumbs = sections.map((s) => [...s.ancestors, s.text].join(" > "));
+  assert(breadcrumbs.includes("Gotchas"), "parses H1 Gotchas");
+  assert(breadcrumbs.includes("Gotchas > Auth retry storm"), "parses H2 under H1");
+  assert(
+    breadcrumbs.includes("Gotchas > Auth retry storm > Verify"),
+    "parses H3 under H2"
+  );
+  assert(breadcrumbs.includes("Appendix"), "parses second top-level H1");
+
+  const found = findSection(sections, ["Gotchas", "Auth retry storm"]);
+  assert(found.level === 2 && found.text === "Auth retry storm", "findSection returns H2 match");
+
+  process.stderr.write("\nappend happy path\n");
+  await editSection(vault, "demo/gotchas", "append", ["Gotchas", "Auth retry storm"], "**New note**: also add metrics.");
+  let updated = fs.readFileSync(path.join(FIXTURE, "demo", "gotchas.md"), "utf-8");
+  assert(updated.includes("**New note**: also add metrics."), "appended content present");
+  // Verify the addition lives inside the right section — must appear before the H3 Verify subsection? Actually
+  // append goes to the end of the section body, which is *before* the next same-or-higher heading. The H3 Verify is
+  // a child, so the section ends at the next H2 (Cache stampede). Addition should land between Verify section and
+  // Cache stampede.
+  const newIdx = updated.indexOf("**New note**: also add metrics.");
+  const cacheIdx = updated.indexOf("## Cache stampede");
+  const verifyIdx = updated.indexOf("### Verify");
+  assert(verifyIdx < newIdx && newIdx < cacheIdx, "appended content lands after subsections, before next sibling H2");
+
+  process.stderr.write("\nreplace happy path (wipes subsections)\n");
+  await editSection(vault, "demo/gotchas", "replace", ["Gotchas", "Auth retry storm"], "Section was rewritten.");
+  updated = fs.readFileSync(path.join(FIXTURE, "demo", "gotchas.md"), "utf-8");
+  assert(updated.includes("## Auth retry storm"), "heading preserved on replace");
+  assert(updated.includes("Section was rewritten."), "replacement body present");
+  assert(!updated.includes("### Verify"), "subsection wiped on replace");
+  assert(!updated.includes("**Symptom**: clients hammer"), "old body wiped on replace");
+  assert(updated.includes("## Cache stampede"), "next sibling section preserved");
+  assert(updated.includes("# Appendix"), "trailing top-level section preserved");
+
+  process.stderr.write("\nfrontmatter preservation\n");
+  assert(updated.startsWith("---\n"), "frontmatter still leads");
+  assert(updated.includes("title: Gotchas"), "frontmatter title preserved");
+  assert(updated.includes("tags: [demo, gotcha]"), "frontmatter tags preserved");
+
+  process.stderr.write("\nempty replace clears body but keeps heading\n");
+  setupFixture();
+  await editSection(vault, "demo/gotchas", "replace", ["Gotchas", "Cache stampede"], "");
+  updated = fs.readFileSync(path.join(FIXTURE, "demo", "gotchas.md"), "utf-8");
+  assert(updated.includes("## Cache stampede"), "empty replace keeps heading");
+  assert(!updated.includes("**Symptom**: thundering herd"), "empty replace clears body");
+
+  process.stderr.write("\nrejections\n");
+  setupFixture();
+  await expectThrow(
+    () => editSection(vault, "demo/missing", "append", ["Gotchas"], "x"),
+    "Note not found",
+    "rejects missing note"
+  );
+  await expectThrow(
+    () => editSection(vault, "demo/gotchas", "append", [], "x"),
+    "non-empty array",
+    "rejects empty headingPath"
+  );
+  await expectThrow(
+    () => editSection(vault, "demo/gotchas", "append", ["Nonexistent"], "x"),
+    "headingPath not found",
+    "rejects unmatched path"
+  );
+  await expectThrow(
+    () => editSection(vault, "demo/gotchas", "append", ["Auth retry storm"], "x"),
+    "headingPath not found",
+    "rejects path missing ancestor (loose match disabled)"
+  );
+  await expectThrow(
+    () => editSection(vault, "demo/gotchas", "append", ["Gotchas", "Auth retry storm"], "Link to [[demo/ghost]]"),
+    "unresolved wiki-links",
+    "rejects dead wiki-link in append content"
+  );
+  await expectThrow(
+    () => editSection(vault, "demo/gotchas", "append", ["Gotchas", "Auth retry storm"], "   "),
+    "content cannot be empty",
+    "rejects empty content for append"
+  );
+  await expectThrow(
+    () => editSection(vault, "demo/gotchas", "frob", ["Gotchas"], "x"),
+    "mode must be",
+    "rejects unknown mode"
+  );
+
+  process.stderr.write("\nambiguity rejection\n");
+  // Add a second "Auth retry storm" under Appendix to force ambiguity? They'd have different ancestors,
+  // so strict matching would NOT consider them ambiguous. To prove ambiguity rejection works, we need
+  // two sections with identical ancestors + text. Easiest: duplicate H2 "Cache stampede" under Gotchas.
+  const ambiguous = SAMPLE.replace(
+    "# Appendix",
+    "## Cache stampede\n\nDuplicate under same H1.\n\n# Appendix"
+  );
+  fs.writeFileSync(path.join(FIXTURE, "demo", "gotchas.md"), ambiguous);
+  await vault.reindex();
+  await expectThrow(
+    () => editSection(vault, "demo/gotchas", "append", ["Gotchas", "Cache stampede"], "x"),
+    "ambiguous",
+    "rejects ambiguous path (two sections with same ancestor + text)"
+  );
+
+  process.stderr.write("\ncode-fence false-heading immunity\n");
+  setupFixture();
+  const fenced = SAMPLE.replace(
+    "Trailing notes here.",
+    "```\n## Not a real heading\n```\n\nTrailing notes here."
+  );
+  fs.writeFileSync(path.join(FIXTURE, "demo", "gotchas.md"), fenced);
+  await vault.reindex();
+  await editSection(vault, "demo/gotchas", "append", ["Appendix"], "Real append.");
+  updated = fs.readFileSync(path.join(FIXTURE, "demo", "gotchas.md"), "utf-8");
+  assert(updated.includes("Real append."), "appended past code-fenced false heading");
+  assert(updated.includes("```\n## Not a real heading\n```"), "code fence body untouched");
+
+  process.stderr.write("\natomic write cleanup\n");
+  const leftovers = fs
+    .readdirSync(path.join(FIXTURE, "demo"))
+    .filter((f) => f.includes(".tmp-"));
+  assert(leftovers.length === 0, `no .tmp-* leftovers (found: ${leftovers.join(", ")})`);
+
+  teardown();
+  if (failed > 0) {
+    process.stderr.write(`\n✗ ${failed} assertion(s) failed\n`);
+    process.exit(1);
+  }
+  process.stderr.write("\n✓ All section-edit assertions passed.\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  teardown();
+  process.exit(1);
+});

--- a/vault/README.md
+++ b/vault/README.md
@@ -115,8 +115,10 @@ Agents can author notes directly through two MCP tools (the CLI does not current
 
 - **`vault_create_note`** — create a new note. Required: `id`, `type`, `title`, `body`. Optional: `tags`, `description`, `summary`, `status` (defaults to `current`). Fails on id collision, missing required fields, unknown status, or unresolved wiki-links in the body. `date` and `lastVerified` are stamped to today.
 - **`vault_write`** — update an existing note. `content` may be either full markdown with a leading `---` frontmatter block (merge-patched over existing frontmatter; body replaced) or body-only markdown (existing frontmatter preserved; body replaced). Fails if the note doesn't exist, the body is empty, or the body introduces unresolved wiki-links.
+- **`vault_append_section`** — append content to a single heading-section, selected by `headingPath` (strict ancestor chain of heading texts, e.g. `["Gotchas", "Auth retry storm"]`). Content lands after the section's last non-blank body line, before the next same-or-higher heading. The heading and frontmatter are untouched.
+- **`vault_replace_section`** — replace the body of a single heading-section (same path semantics). The heading line is preserved verbatim; everything between it and the next same-or-higher heading — including nested subsections — is replaced. Pass an empty `content` to clear the section body. Use this for low-overhead incremental updates (one gotcha, one runbook step) instead of round-tripping the whole note.
 
-Both tools write atomically (tmp-file + rename), then reindex the vault and resync embeddings so the write is immediately searchable. Both return the note as read back from disk.
+All four tools write atomically (tmp-file + rename), then reindex the vault and resync embeddings so the write is immediately searchable. All return the note as read back from disk. Section edits fail on path miss, ambiguous match, or unresolved wiki-links in the result.
 
 Use these to keep agent-authored content subject to the same schema and link-integrity rules as hand-written notes.
 


### PR DESCRIPTION
Closes #23.

## Summary
- New `lib/sections.js` — line-preserving heading-tree parser, kept separate from `chunks.js` (retrieval merges short sections / splits long; edits need every boundary verbatim).
- `editSection(vault, id, mode, headingPath, content)` in `lib/vault-write.js`: strict ancestor-chain path matching, frontmatter untouched, atomic tmp+rename, dead-wiki-link guard on the resulting body.
- Two new MCP tools — `vault_append_section` (lands content after the section's last non-blank body line, before the next same-or-higher heading) and `vault_replace_section` (swaps body, preserving the heading line; wipes nested subsections).
- 29-assertion test suite covering parse/match, subsection semantics, frontmatter preservation, code-fence immunity, and every rejection path (missing note, empty/unmatched/ambiguous/partial path, dead link, empty append, unknown mode).

Retrieval eval unchanged at recall@5 = 64.3% / MRR = 0.559.

## Test plan
- [x] `node test/section-edit.test.js` — 29/29 pass
- [x] `npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/**/*.js` — clean
- [x] `node index.js lint --vault vault` — no issues
- [x] `node test/retrieval/eval.js` — no retrieval regression
- [ ] CI green on `feat/section-edit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)