### PR TITLE
feat: stub creation + suggested-links on write (#24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd web && npm install && cd ..
 
       - name: Type check (CLI)
-        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js test/section-edit.test.js
+        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js test/section-edit.test.js test/stubs-and-suggestions.test.js
 
       - name: Type check (web)
         run: cd web && npx tsc --noEmit && cd ..
@@ -58,6 +58,9 @@ jobs:
 
       - name: Section-edit assertions
         run: node test/section-edit.test.js
+
+      - name: Stubs + suggested-links assertions
+        run: node test/stubs-and-suggestions.test.js
 
       - name: Lint web (if eslintrc exists)
         run: cd web && npm run lint 2>/dev/null || echo "No lint script defined"

--- a/index.js
+++ b/index.js
@@ -255,6 +255,7 @@ program
   )
   .option("--format <fmt>", "Output format: text | json | github", "text")
   .option("--stale-days <n>", "Stale threshold in days for lastVerified", "180")
+  .option("--stale-stub-days <n>", "Age (days) at which draft stubs are flagged", "7")
   .action(async (options) => {
     const vaultDir = program.opts().vault;
     const vault = new Vault(vaultDir);
@@ -267,6 +268,7 @@ program
 
     const findings = await lintVault(vault, {
       staleDays: parseInt(options.staleDays, 10),
+      staleStubDays: parseInt(options.staleStubDays, 10),
     });
 
     const fmt = options.format;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -12,12 +12,14 @@ import { SCHEMAS } from "./schemas.js";
  */
 
 const DEFAULT_STALE_DAYS = 180;
+const DEFAULT_STALE_STUB_DAYS = 7;
 const MIN_BODY_CHARS = 200;
 const MAX_BODY_CHARS = 15000;
 const DUP_THRESHOLD = 0.55;
 
 export async function lintVault(vault, opts = {}) {
   const staleDays = opts.staleDays ?? DEFAULT_STALE_DAYS;
+  const staleStubDays = opts.staleStubDays ?? DEFAULT_STALE_STUB_DAYS;
   const findings = [];
   const noteIds = new Set(vault.index.map((n) => n.id));
 
@@ -41,6 +43,7 @@ export async function lintVault(vault, opts = {}) {
     pushHeadingSkips(findings, note, file, raw, lines.bodyStartLine);
     pushSizeFindings(findings, note, file, raw, lines.bodyStartLine);
     pushStaleDate(findings, note, file, lines, staleDays);
+    pushStaleStub(findings, note, file, lines, staleStubDays);
     pushTypedSchema(findings, note, file, raw, lines.bodyStartLine);
   }
 
@@ -236,6 +239,25 @@ function pushStaleDate(findings, note, file, lines, staleDays) {
       noteId: note.id,
       file,
       line: lineFor(lines, "lastVerified"),
+    });
+  }
+}
+
+function pushStaleStub(findings, note, file, lines, staleStubDays) {
+  const tags = note.frontmatter?.tags ?? [];
+  const isStub = tags.includes("stub") && note.status === "draft";
+  if (!isStub) return;
+  const d = note.frontmatter?.date;
+  if (!d || !ISO_DATE_RE.test(d)) return;
+  const ageDays = Math.floor((Date.now() - Date.parse(d)) / 86400000);
+  if (ageDays > staleStubDays) {
+    findings.push({
+      level: "warning",
+      code: "stale-stub",
+      message: `Stub "${note.id}" is ${ageDays} days old (> ${staleStubDays}) and still a draft. Fill it in or delete it.`,
+      noteId: note.id,
+      file,
+      line: lineFor(lines, "date"),
     });
   }
 }

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -164,13 +164,14 @@ server.registerTool(
   "vault_lint",
   {
     description:
-      "Lint the vault for content-quality issues: dead wiki-links, missing frontmatter (title/type/tags/description), orphan notes, heading hierarchy skips, oversize/undersize notes, duplicate-candidate pairs (Jaccard on tokens), stale lastVerified dates, and unknown enum values for status/type. Returns findings as a JSON array — each finding has { level: 'error'|'warning'|'info', code, message, noteId, file, line }. Codes are stable (e.g. 'dead-link', 'missing-frontmatter-field'). Call this to check vault health before authoring new notes, or after large refactors.",
+      "Lint the vault for content-quality issues: dead wiki-links, missing frontmatter (title/type/tags/description), orphan notes, heading hierarchy skips, oversize/undersize notes, duplicate-candidate pairs (Jaccard on tokens), stale lastVerified dates, stale stubs (draft notes with tags: [stub] older than staleStubDays), and unknown enum values for status/type. Returns findings as a JSON array — each finding has { level: 'error'|'warning'|'info', code, message, noteId, file, line }. Codes are stable (e.g. 'dead-link', 'stale-stub'). Call this to check vault health before authoring new notes, or after large refactors.",
     inputSchema: {
       staleDays: z.number().int().positive().optional(),
+      staleStubDays: z.number().int().positive().optional(),
     },
   },
-  safe(async ({ staleDays }) => {
-    const findings = await lintVault(vault, { staleDays });
+  safe(async ({ staleDays, staleStubDays }) => {
+    const findings = await lintVault(vault, { staleDays, staleStubDays });
     return {
       content: [{ type: "text", text: JSON.stringify(findings, null, 2) }],
     };
@@ -407,7 +408,7 @@ server.registerTool(
   "vault_create_note",
   {
     description:
-      "Create a new vault note. Fails if the id already exists, if required fields are missing, or if the body contains unresolved wiki-links (`[[target]]` where `target` is not an existing note id). Frontmatter is built from the provided fields; `date` and `lastVerified` default to today. After writing, the vault is reindexed and embeddings are synced so the new note is immediately searchable. Returns the created note as read back from disk. Use this to author new notes from an agent workflow; use vault_write to edit an existing note.",
+      "Create a new vault note. Fails if the id already exists or required fields are missing. Unresolved `[[target]]` wiki-links in the body auto-create draft stub notes (tags: [stub]) pointing back at this note, so authoring never blocks on chain-of-reference; the `createdStubs` field reports which ids were stubbed. Bare mentions of existing note titles or glossary terms come back as `suggestedLinks` (not auto-inserted — the agent decides). Frontmatter is built from the provided fields; `date` and `lastVerified` default to today. After writing, the vault is reindexed and embeddings are synced. Returns `{ note, createdStubs, suggestedLinks }`.",
     inputSchema: {
       id: z.string(),
       type: z.string(),
@@ -420,11 +421,20 @@ server.registerTool(
     },
   },
   safe(async (params) => {
-    const result = await createNote(vault, params);
+    const result = await createNote(vault, params, { autoStub: true });
     await resyncAfterWrite();
     const note = await vault.getNote(result.id);
     return {
-      content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { note, createdStubs: result.createdStubs, suggestedLinks: result.suggestedLinks },
+            null,
+            2
+          ),
+        },
+      ],
     };
   })
 );
@@ -433,18 +443,27 @@ server.registerTool(
   "vault_write",
   {
     description:
-      "Update an existing vault note. `content` may be either (a) full markdown with a leading `---` frontmatter block — frontmatter is merge-patched over the existing file's frontmatter (new keys win, untouched keys preserved) and body is replaced; or (b) body-only markdown (no leading frontmatter) — existing frontmatter is preserved verbatim and only the body is replaced. Fails if the note does not exist (use vault_create_note), if the body is empty, or if the body introduces unresolved wiki-links. After writing, the vault is reindexed and embeddings are synced. Returns the updated note as read back from disk.",
+      "Update an existing vault note. `content` may be either (a) full markdown with a leading `---` frontmatter block — frontmatter is merge-patched over the existing file's frontmatter (new keys win, untouched keys preserved) and body is replaced; or (b) body-only markdown (no leading frontmatter) — existing frontmatter is preserved verbatim and only the body is replaced. Fails if the note does not exist (use vault_create_note) or if the body is empty. Unresolved `[[target]]` wiki-links auto-stub (see vault_create_note). `suggestedLinks` returns bare mentions of known titles/terms. Returns `{ note, createdStubs, suggestedLinks }`.",
     inputSchema: {
       id: z.string(),
       content: z.string(),
     },
   },
   safe(async ({ id, content }) => {
-    const result = await writeNote(vault, id, content);
+    const result = await writeNote(vault, id, content, { autoStub: true });
     await resyncAfterWrite();
     const note = await vault.getNote(result.id);
     return {
-      content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { note, createdStubs: result.createdStubs, suggestedLinks: result.suggestedLinks },
+            null,
+            2
+          ),
+        },
+      ],
     };
   })
 );
@@ -453,7 +472,7 @@ server.registerTool(
   "vault_append_section",
   {
     description:
-      "Append `content` to a single heading-section of an existing note, identified by `headingPath` — a strict ancestor chain of heading texts (e.g. `[\"Gotchas\", \"Auth retry storm\"]` for an H2 \"Auth retry storm\" nested directly under H1 \"Gotchas\"). The new content lands after the section's last non-blank body line, before the next same-or-higher heading. The heading line itself is never modified, frontmatter is left untouched. Fails if the path matches zero or multiple sections, or if the resulting body has unresolved wiki-links. After writing, the vault is reindexed and embeddings are synced. Use this for low-overhead incremental updates (e.g. adding a single gotcha) instead of round-tripping the whole note through vault_write.",
+      "Append `content` to a single heading-section of an existing note, identified by `headingPath` — a strict ancestor chain of heading texts (e.g. `[\"Gotchas\", \"Auth retry storm\"]` for an H2 \"Auth retry storm\" nested directly under H1 \"Gotchas\"). The new content lands after the section's last non-blank body line, before the next same-or-higher heading. The heading line itself is never modified, frontmatter is left untouched. Fails if the path matches zero or multiple sections. Unresolved `[[target]]` wiki-links auto-stub (see vault_create_note); `suggestedLinks` returns bare mentions of known titles/terms. Returns `{ note, createdStubs, suggestedLinks }`.",
     inputSchema: {
       id: z.string(),
       headingPath: z.array(z.string()).min(1),
@@ -461,11 +480,20 @@ server.registerTool(
     },
   },
   safe(async ({ id, headingPath, content }) => {
-    const result = await editSection(vault, id, "append", headingPath, content);
+    const result = await editSection(vault, id, "append", headingPath, content, { autoStub: true });
     await resyncAfterWrite();
     const note = await vault.getNote(result.id);
     return {
-      content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { note, createdStubs: result.createdStubs, suggestedLinks: result.suggestedLinks },
+            null,
+            2
+          ),
+        },
+      ],
     };
   })
 );
@@ -474,7 +502,7 @@ server.registerTool(
   "vault_replace_section",
   {
     description:
-      "Replace the body of a single heading-section. `headingPath` selects the section under strict-ancestor-chain semantics (see vault_append_section). The heading line is preserved verbatim; everything between it and the next same-or-higher heading — including any nested subsections — is replaced with `content`. Pass an empty `content` to clear the section body. Frontmatter is untouched. Fails on path miss, ambiguous match, or unresolved wiki-links in the result. After writing, the vault is reindexed and embeddings are synced.",
+      "Replace the body of a single heading-section. `headingPath` selects the section under strict-ancestor-chain semantics (see vault_append_section). The heading line is preserved verbatim; everything between it and the next same-or-higher heading — including any nested subsections — is replaced with `content`. Pass an empty `content` to clear the section body. Frontmatter is untouched. Fails on path miss or ambiguous match. Unresolved `[[target]]` wiki-links auto-stub; `suggestedLinks` returns bare mentions. Returns `{ note, createdStubs, suggestedLinks }`.",
     inputSchema: {
       id: z.string(),
       headingPath: z.array(z.string()).min(1),
@@ -482,11 +510,20 @@ server.registerTool(
     },
   },
   safe(async ({ id, headingPath, content }) => {
-    const result = await editSection(vault, id, "replace", headingPath, content);
+    const result = await editSection(vault, id, "replace", headingPath, content, { autoStub: true });
     await resyncAfterWrite();
     const note = await vault.getNote(result.id);
     return {
-      content: [{ type: "text", text: JSON.stringify(note, null, 2) }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { note, createdStubs: result.createdStubs, suggestedLinks: result.suggestedLinks },
+            null,
+            2
+          ),
+        },
+      ],
     };
   })
 );

--- a/lib/vault-write.js
+++ b/lib/vault-write.js
@@ -113,14 +113,136 @@ function extractWikiTargets(body) {
     .filter(Boolean);
 }
 
-function findDeadLinks(vault, body, selfId = null) {
+function findDeadLinks(vault, body, selfId = null, extraIds = []) {
   const noteIds = new Set(vault.index.map((n) => n.id));
   if (selfId) noteIds.add(selfId);
+  for (const id of extraIds) noteIds.add(id);
   const dead = [];
   for (const target of extractWikiTargets(body)) {
     if (!noteIds.has(target)) dead.push(target);
   }
   return [...new Set(dead)];
+}
+
+function titleCaseFromId(id) {
+  const last = id.split("/").pop() || id;
+  return last
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+async function writeStubFile(vault, targetId, sourceId) {
+  const filePath = resolveInsideVault(vault.vaultDir, targetId);
+  // Don't overwrite if someone raced us to it.
+  try {
+    await fs.stat(filePath);
+    return false;
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+  const today = new Date().toISOString().split("T")[0];
+  const fm = {
+    title: titleCaseFromId(targetId),
+    type: "overview",
+    status: "draft",
+    date: today,
+    lastVerified: today,
+    description: "Stub — to be written.",
+    summary: "Stub — to be written.",
+    tags: ["stub"],
+  };
+  const body = `# ${fm.title}\n\nThis stub was auto-created from a reference in [[${sourceId}]]. Replace this body with the real content.\n`;
+  const content = `---\n${serializeFrontmatter(fm)}\n---\n\n${body}`;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await atomicWrite(filePath, content);
+  return true;
+}
+
+/**
+ * Create stubs for any unresolved wiki-link targets in `body`. Skips
+ * targets whose shape isn't a valid note id. Returns the ids actually
+ * created (caller is responsible for reindexing). Assumes the source
+ * note itself is a valid link target — we don't stub the source.
+ */
+async function autoStubDeadLinks(vault, body, sourceId) {
+  const targets = extractWikiTargets(body);
+  const existing = new Set(vault.index.map((n) => n.id));
+  existing.add(sourceId);
+  const seen = new Set();
+  const created = [];
+  for (const target of targets) {
+    if (seen.has(target) || existing.has(target)) continue;
+    seen.add(target);
+    try {
+      validateId(target);
+    } catch {
+      continue; // invalid id shape — leave as a real dead link for the linter
+    }
+    const wrote = await writeStubFile(vault, target, sourceId);
+    if (wrote) created.push(target);
+  }
+  return created;
+}
+
+/**
+ * Suggest wiki-links the author probably meant but didn't write: bare
+ * mentions of known note titles or glossary terms that aren't already
+ * linked. Case-insensitive, word-boundary, strips code fences and inline
+ * code. Dedups per target, reports a count + first-occurrence line.
+ */
+function computeSuggestedLinks(vault, body, selfId) {
+  const stripped = body
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`\n]*`/g, "")
+    .replace(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g, " ");
+  const lines = stripped.split("\n");
+  const alreadyLinked = new Set(extractWikiTargets(body));
+
+  const candidates = [];
+  for (const note of vault.index) {
+    if (note.id === selfId) continue;
+    if (alreadyLinked.has(note.id)) continue;
+    if (note.title) candidates.push({ target: note.id, text: note.title, matchedOn: "title" });
+    if (note.type === "glossary" && Array.isArray(note.frontmatter?.terms)) {
+      for (const term of note.frontmatter.terms) {
+        if (term && term.trim()) {
+          candidates.push({ target: note.id, text: term.trim(), matchedOn: "term" });
+        }
+      }
+    }
+  }
+
+  const results = new Map();
+  for (const cand of candidates) {
+    const esc = cand.text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`(^|\\W)(${esc})(\\W|$)`, "gi");
+    let count = 0;
+    let firstLine = null;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      re.lastIndex = 0;
+      const matches = line.match(re);
+      if (matches) {
+        count += matches.length;
+        if (firstLine === null) firstLine = i;
+      }
+    }
+    if (count === 0) continue;
+    const key = `${cand.target}::${cand.matchedOn}::${cand.text.toLowerCase()}`;
+    const prev = results.get(key);
+    if (!prev || count > prev.count) {
+      results.set(key, {
+        target: cand.target,
+        matchedText: cand.text,
+        matchedOn: cand.matchedOn,
+        count,
+        firstLine,
+      });
+    }
+  }
+  return [...results.values()].sort((a, b) => b.count - a.count || a.target.localeCompare(b.target));
 }
 
 async function atomicWrite(filePath, content) {
@@ -140,11 +262,16 @@ async function atomicWrite(filePath, content) {
 
 /**
  * Create a new note. Fails on id collision, missing required fields, or
- * unresolved wiki-links in the body.
+ * — when `opts.autoStub` is false (default) — unresolved wiki-links. When
+ * `opts.autoStub` is true, each unresolved target with a valid id shape
+ * becomes a draft stub note (tags: [stub]) pointing back at this note;
+ * invalid id shapes still throw.
  *
- * Returns { id, path, content }. Caller reindexes and re-reads as needed.
+ * Returns { id, path, content, createdStubs, suggestedLinks }.
+ * `suggestedLinks` is always computed; `createdStubs` is empty unless
+ * autoStub is true.
  */
-export async function createNote(vault, params) {
+export async function createNote(vault, params, opts = {}) {
   const {
     id,
     type,
@@ -155,6 +282,7 @@ export async function createNote(vault, params) {
     summary = "",
     status = "current",
   } = params || {};
+  const autoStub = opts.autoStub === true;
 
   validateId(id);
   if (!type) throw new Error("type is required");
@@ -179,7 +307,11 @@ export async function createNote(vault, params) {
   }
   if (exists) throw new Error(`Note already exists: ${id}`);
 
-  const dead = findDeadLinks(vault, body, id);
+  let createdStubs = [];
+  if (autoStub) {
+    createdStubs = await autoStubDeadLinks(vault, body, id);
+  }
+  const dead = findDeadLinks(vault, body, id, createdStubs);
   if (dead.length > 0) {
     throw new Error(
       `Body has unresolved wiki-links: ${dead.join(", ")}. Create targets first, or fix the reference.`
@@ -202,7 +334,14 @@ export async function createNote(vault, params) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await atomicWrite(filePath, content);
 
-  return { id, path: path.relative(vault.vaultDir, filePath), content };
+  const suggestedLinks = computeSuggestedLinks(vault, body, id);
+  return {
+    id,
+    path: path.relative(vault.vaultDir, filePath),
+    content,
+    createdStubs,
+    suggestedLinks,
+  };
 }
 
 /**
@@ -218,7 +357,8 @@ export async function createNote(vault, params) {
  * Fails if the note doesn't exist (use createNote) or the body introduces
  * unresolved wiki-links.
  */
-export async function writeNote(vault, id, content) {
+export async function writeNote(vault, id, content, opts = {}) {
+  const autoStub = opts.autoStub === true;
   validateId(id);
   if (typeof content !== "string") throw new Error("content must be a string");
 
@@ -253,7 +393,11 @@ export async function writeNote(vault, id, content) {
   body = body.trim();
   if (!body) throw new Error("body cannot be empty");
 
-  const dead = findDeadLinks(vault, body, id);
+  let createdStubs = [];
+  if (autoStub) {
+    createdStubs = await autoStubDeadLinks(vault, body, id);
+  }
+  const dead = findDeadLinks(vault, body, id, createdStubs);
   if (dead.length > 0) {
     throw new Error(
       `Body has unresolved wiki-links: ${dead.join(", ")}. Create targets first, or fix the reference.`
@@ -263,7 +407,14 @@ export async function writeNote(vault, id, content) {
   const newContent = `---\n${serializeFrontmatter(mergedFm)}\n---\n\n${body}\n`;
   await atomicWrite(filePath, newContent);
 
-  return { id, path: path.relative(vault.vaultDir, filePath), content: newContent };
+  const suggestedLinks = computeSuggestedLinks(vault, body, id);
+  return {
+    id,
+    path: path.relative(vault.vaultDir, filePath),
+    content: newContent,
+    createdStubs,
+    suggestedLinks,
+  };
 }
 
 /**
@@ -274,7 +425,8 @@ export async function writeNote(vault, id, content) {
  * Fails if the note doesn't exist, the path doesn't match (or matches more
  * than one section), or the resulting body introduces unresolved wiki-links.
  */
-export async function editSection(vault, id, mode, headingPath, content) {
+export async function editSection(vault, id, mode, headingPath, content, opts = {}) {
+  const autoStub = opts.autoStub === true;
   if (mode !== "append" && mode !== "replace") {
     throw new Error(`mode must be "append" or "replace", got ${mode}`);
   }
@@ -313,7 +465,11 @@ export async function editSection(vault, id, mode, headingPath, content) {
   let updatedBody = updatedLines.join("\n");
   if (trailingNewline && !updatedBody.endsWith("\n")) updatedBody += "\n";
 
-  const dead = findDeadLinks(vault, updatedBody, id);
+  let createdStubs = [];
+  if (autoStub) {
+    createdStubs = await autoStubDeadLinks(vault, updatedBody, id);
+  }
+  const dead = findDeadLinks(vault, updatedBody, id, createdStubs);
   if (dead.length > 0) {
     throw new Error(
       `Body has unresolved wiki-links after edit: ${dead.join(
@@ -325,7 +481,14 @@ export async function editSection(vault, id, mode, headingPath, content) {
   const newContent = fmText + updatedBody;
   await atomicWrite(filePath, newContent);
 
-  return { id, path: path.relative(vault.vaultDir, filePath), content: newContent };
+  const suggestedLinks = computeSuggestedLinks(vault, updatedBody, id);
+  return {
+    id,
+    path: path.relative(vault.vaultDir, filePath),
+    content: newContent,
+    createdStubs,
+    suggestedLinks,
+  };
 }
 
 // Exported for testing.
@@ -335,4 +498,7 @@ export const __test = {
   serializeFrontmatter,
   validateId,
   extractWikiTargets,
+  titleCaseFromId,
+  computeSuggestedLinks,
+  autoStubDeadLinks,
 };

--- a/test/stubs-and-suggestions.test.js
+++ b/test/stubs-and-suggestions.test.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Stub creation + suggested-links assertions — issue #24.
+ *
+ * Exercises the autoStub opt-in through createNote, writeNote, editSection,
+ * plus the computeSuggestedLinks helper and the stale-stub linter rule.
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Vault } from "../lib/vault.js";
+import { createNote, writeNote, editSection, __test } from "../lib/vault-write.js";
+import { lintVault } from "../lib/linter.js";
+
+const { computeSuggestedLinks, titleCaseFromId } = __test;
+
+const FIXTURE = path.join(os.tmpdir(), `vault-stubs-fixture-${process.pid}`);
+
+function setupFixture() {
+  if (fs.existsSync(FIXTURE)) fs.rmSync(FIXTURE, { recursive: true, force: true });
+  fs.mkdirSync(path.join(FIXTURE, "demo"), { recursive: true });
+  fs.writeFileSync(
+    path.join(FIXTURE, "demo", "seed.md"),
+    `---\ntitle: Authentication\ntype: overview\nstatus: current\ndate: 2026-01-01\nlastVerified: 2026-04-20\ndescription: Seed note about authentication\ntags: [seed, auth]\n---\n\n# Authentication\n\nLinkable body.\n`
+  );
+  fs.writeFileSync(
+    path.join(FIXTURE, "demo", "terms.md"),
+    `---\ntitle: Core terms\ntype: glossary\nstatus: current\ndate: 2026-01-01\nlastVerified: 2026-04-20\nterms: [JWT, Refresh Token]\ntags: [glossary]\n---\n\n# Core terms\n\n## JWT\n\nJSON Web Token.\n\n## Refresh Token\n\nLong-lived credential.\n`
+  );
+}
+function teardown() {
+  try { fs.rmSync(FIXTURE, { recursive: true, force: true }); } catch {}
+}
+
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) process.stderr.write(`  ✓ ${msg}\n`);
+  else { failed++; process.stderr.write(`  ✗ ${msg}\n`); }
+}
+async function expectThrow(fn, matcher, msg) {
+  try { await fn(); } catch (err) {
+    const ok = typeof matcher === "string" ? err.message.includes(matcher) : matcher.test(err.message);
+    assert(ok, `${msg} (got: ${err.message})`); return;
+  }
+  assert(false, `${msg} (no error thrown)`);
+}
+
+async function main() {
+  setupFixture();
+  const vault = new Vault(FIXTURE);
+  await vault.reindex();
+
+  process.stderr.write("titleCaseFromId\n");
+  assert(titleCaseFromId("demo/my-new-thing") === "My New Thing", "kebab → title case");
+  assert(titleCaseFromId("demo/multi_word_id") === "Multi Word Id", "snake → title case");
+
+  process.stderr.write("\nautoStub: createNote stubs unresolved targets\n");
+  const r1 = await createNote(
+    vault,
+    {
+      id: "demo/article",
+      type: "feature",
+      title: "Article",
+      body: "## What\n\nRefers to [[demo/ghost-one]] and [[demo/ghost-two]].\n\n## Why\n\nReason.\n\n## How\n\nSteps.",
+      tags: ["demo"],
+    },
+    { autoStub: true }
+  );
+  assert(r1.createdStubs.length === 2, "two stubs created");
+  assert(r1.createdStubs.includes("demo/ghost-one"), "ghost-one stubbed");
+  assert(r1.createdStubs.includes("demo/ghost-two"), "ghost-two stubbed");
+  assert(fs.existsSync(path.join(FIXTURE, "demo", "ghost-one.md")), "stub file on disk");
+  const stubContent = fs.readFileSync(path.join(FIXTURE, "demo", "ghost-one.md"), "utf-8");
+  assert(stubContent.includes("status: draft"), "stub status is draft");
+  assert(stubContent.includes("tags: [stub]"), "stub tag is [stub]");
+  assert(stubContent.includes("[[demo/article]]"), "stub backlinks to source");
+  assert(stubContent.includes("title: Ghost One"), "stub title is title-cased id");
+
+  process.stderr.write("\nautoStub default off (strict) keeps old behavior\n");
+  setupFixture();
+  await vault.reindex();
+  await expectThrow(
+    () =>
+      createNote(vault, {
+        id: "demo/strict",
+        type: "feature",
+        title: "Strict",
+        body: "## What\n\n[[demo/ghost]]\n\n## Why\n\nx\n\n## How\n\ny",
+      }),
+    "unresolved wiki-links",
+    "default (no opts) still throws on dead links"
+  );
+
+  process.stderr.write("\nautoStub: writeNote stubs + suggests\n");
+  setupFixture();
+  await vault.reindex();
+  const r2 = await writeNote(
+    vault,
+    "demo/seed",
+    "Plain authentication notes mentioning JWT and Refresh Token rotation. Also refers to [[demo/new-thing]].\n",
+    { autoStub: true }
+  );
+  assert(r2.createdStubs.includes("demo/new-thing"), "writeNote stubbed new-thing");
+  // suggestedLinks should surface glossary terms JWT and Refresh Token (they point at demo/terms).
+  const termTargets = r2.suggestedLinks.filter((s) => s.target === "demo/terms").map((s) => s.matchedText);
+  assert(termTargets.includes("JWT"), "suggests JWT from glossary");
+  assert(termTargets.includes("Refresh Token"), "suggests Refresh Token from glossary");
+  assert(r2.suggestedLinks.every((s) => s.target !== "demo/seed"), "does not suggest self");
+
+  process.stderr.write("\nsuggestedLinks skips already-linked targets\n");
+  setupFixture();
+  await vault.reindex();
+  // Body references Authentication by its title AND already links demo/seed — the title suggestion should be dropped.
+  const r3 = await createNote(
+    vault,
+    {
+      id: "demo/uses-auth",
+      type: "overview",
+      title: "Uses authentication",
+      body: "# Notes\n\nWe build on [[demo/seed]] for authentication handling.\n",
+    },
+    { autoStub: true }
+  );
+  assert(
+    r3.suggestedLinks.every((s) => s.target !== "demo/seed"),
+    "target already wiki-linked does not get suggested"
+  );
+
+  process.stderr.write("\nsuggestedLinks ignores code fences and inline code\n");
+  setupFixture();
+  await vault.reindex();
+  const r4 = await createNote(
+    vault,
+    {
+      id: "demo/fenced",
+      type: "overview",
+      title: "Fenced",
+      body: "# Fenced\n\nHere is some code:\n\n```\nAuthentication is a keyword used in auth().\n```\n\nAnd `Authentication` inline is also code. Body has no bare mention.\n",
+    },
+    { autoStub: true }
+  );
+  const authSuggest = r4.suggestedLinks.find((s) => s.target === "demo/seed");
+  assert(!authSuggest, "no suggestion when all mentions are in fences/inline code");
+
+  process.stderr.write("\nsuggestedLinks counts occurrences and reports first line\n");
+  setupFixture();
+  await vault.reindex();
+  const r5 = await createNote(
+    vault,
+    {
+      id: "demo/multi",
+      type: "overview",
+      title: "Multi",
+      body: "# Multi\n\nAuthentication here.\n\nMore on Authentication.\n\nAuthentication last time.\n",
+    },
+    { autoStub: true }
+  );
+  const authHit = r5.suggestedLinks.find((s) => s.target === "demo/seed" && s.matchedOn === "title");
+  assert(authHit && authHit.count >= 3, `counts >=3 occurrences (got ${authHit?.count})`);
+  assert(authHit && typeof authHit.firstLine === "number", "firstLine is a number");
+
+  process.stderr.write("\neditSection auto-stubs\n");
+  setupFixture();
+  await vault.reindex();
+  await createNote(vault, {
+    id: "demo/gotchas",
+    type: "gotcha",
+    title: "Gotchas",
+    body: "## First\n\n**Symptom**: x\n\n**Cause**: y\n\n**Fix**: z\n",
+  });
+  const r6 = await editSection(
+    vault,
+    "demo/gotchas",
+    "append",
+    ["First"],
+    "\n\n**See also**: [[demo/another-stub]].\n",
+    { autoStub: true }
+  );
+  assert(r6.createdStubs.includes("demo/another-stub"), "editSection append stubbed new target");
+  assert(fs.existsSync(path.join(FIXTURE, "demo", "another-stub.md")), "stub file written from section edit");
+
+  process.stderr.write("\nstub idempotent: existing file is not overwritten\n");
+  setupFixture();
+  await vault.reindex();
+  fs.writeFileSync(path.join(FIXTURE, "demo", "preexisting.md"), `---\ntitle: Preexisting\ntype: overview\nstatus: current\ntags: []\n---\n\n# Preexisting\n\nReal content that must not be clobbered.\n`);
+  await vault.reindex();
+  const r7 = await createNote(
+    vault,
+    {
+      id: "demo/source",
+      type: "overview",
+      title: "Source",
+      body: "# Source\n\nLink to [[demo/preexisting]].\n",
+    },
+    { autoStub: true }
+  );
+  assert(r7.createdStubs.length === 0, "no stubs created when target already exists");
+  const preContent = fs.readFileSync(path.join(FIXTURE, "demo", "preexisting.md"), "utf-8");
+  assert(preContent.includes("Real content that must not be clobbered"), "preexisting note untouched");
+
+  process.stderr.write("\ninvalid-shaped target with autoStub still throws (can't stub it)\n");
+  setupFixture();
+  await vault.reindex();
+  await expectThrow(
+    () =>
+      createNote(
+        vault,
+        {
+          id: "demo/bad-target",
+          type: "overview",
+          title: "Bad target",
+          body: "# X\n\nLink to [[../escape]].\n",
+        },
+        { autoStub: true }
+      ),
+    "unresolved wiki-links",
+    "invalid id shape left as dead link, not stubbed"
+  );
+
+  process.stderr.write("\nstale-stub linter rule\n");
+  setupFixture();
+  fs.writeFileSync(
+    path.join(FIXTURE, "demo", "old-stub.md"),
+    `---\ntitle: Old stub\ntype: overview\nstatus: draft\ndate: 2026-01-01\nlastVerified: 2026-01-01\ndescription: Stub — to be written.\nsummary: Stub — to be written.\ntags: [stub]\n---\n\n# Old stub\n\nStub body referencing [[demo/seed]].\n`
+  );
+  fs.writeFileSync(
+    path.join(FIXTURE, "demo", "fresh-stub.md"),
+    `---\ntitle: Fresh stub\ntype: overview\nstatus: draft\ndate: ${new Date().toISOString().slice(0, 10)}\nlastVerified: 2026-04-20\ndescription: Stub — to be written.\nsummary: Stub — to be written.\ntags: [stub]\n---\n\n# Fresh stub\n\nStub body referencing [[demo/seed]].\n`
+  );
+  await vault.reindex();
+  const findings = await lintVault(vault, { staleStubDays: 7 });
+  const stale = findings.filter((f) => f.code === "stale-stub");
+  assert(stale.some((f) => f.noteId === "demo/old-stub"), "flags old stub");
+  assert(!stale.some((f) => f.noteId === "demo/fresh-stub"), "doesn't flag fresh stub");
+  assert(!stale.some((f) => f.noteId === "demo/seed"), "doesn't flag non-stub notes");
+
+  // Filling in the stub (status: current) should clear the warning.
+  fs.writeFileSync(
+    path.join(FIXTURE, "demo", "old-stub.md"),
+    `---\ntitle: Old stub\ntype: overview\nstatus: current\ndate: 2026-01-01\nlastVerified: 2026-01-01\ndescription: Now filled in\ntags: [stub]\n---\n\n# Old stub\n\nReal content now.\n`
+  );
+  await vault.reindex();
+  const after = await lintVault(vault, { staleStubDays: 7 });
+  assert(
+    !after.some((f) => f.code === "stale-stub" && f.noteId === "demo/old-stub"),
+    "filled-in stub no longer flagged"
+  );
+
+  process.stderr.write("\ncomputeSuggestedLinks unit: returns [] on a body with no matches\n");
+  setupFixture();
+  await vault.reindex();
+  const empty = computeSuggestedLinks(vault, "Body talking about pineapples only.\n", null);
+  assert(empty.length === 0, "no suggestions when nothing matches");
+
+  teardown();
+  if (failed > 0) {
+    process.stderr.write(`\n✗ ${failed} assertion(s) failed\n`);
+    process.exit(1);
+  }
+  process.stderr.write("\n✓ All stubs-and-suggestions assertions passed.\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  teardown();
+  process.exit(1);
+});

--- a/vault/README.md
+++ b/vault/README.md
@@ -118,7 +118,15 @@ Agents can author notes directly through two MCP tools (the CLI does not current
 - **`vault_append_section`** — append content to a single heading-section, selected by `headingPath` (strict ancestor chain of heading texts, e.g. `["Gotchas", "Auth retry storm"]`). Content lands after the section's last non-blank body line, before the next same-or-higher heading. The heading and frontmatter are untouched.
 - **`vault_replace_section`** — replace the body of a single heading-section (same path semantics). The heading line is preserved verbatim; everything between it and the next same-or-higher heading — including nested subsections — is replaced. Pass an empty `content` to clear the section body. Use this for low-overhead incremental updates (one gotcha, one runbook step) instead of round-tripping the whole note.
 
-All four tools write atomically (tmp-file + rename), then reindex the vault and resync embeddings so the write is immediately searchable. All return the note as read back from disk. Section edits fail on path miss, ambiguous match, or unresolved wiki-links in the result.
+All four write tools return `{ note, createdStubs, suggestedLinks }`:
+
+- **`note`** — the written note as read back from disk.
+- **`createdStubs`** — ids of any notes auto-created because the body contained unresolved `[[target]]` wiki-links. Each stub starts with `status: draft`, `tags: [stub]`, and a body that backlinks to the source note. Authoring never blocks on chain-of-reference; the agent can fill stubs in later. Invalid id shapes (e.g. `../escape`) still reject.
+- **`suggestedLinks`** — bare mentions of known note titles or glossary `terms` that aren't already wiki-linked. Each entry is `{ target, matchedText, matchedOn: "title" | "term", count, firstLine }`. Not auto-inserted — the agent decides.
+
+All four tools write atomically (tmp-file + rename), then reindex the vault and resync embeddings so the write is immediately searchable. Section edits fail on path miss or ambiguous match.
+
+Draft stubs that haven't been filled in after **`staleStubDays`** (default 7) are flagged by the linter with code `stale-stub`. Tune with `--stale-stub-days <n>` (CLI) or `staleStubDays` (MCP `vault_lint`).
 
 Use these to keep agent-authored content subject to the same schema and link-integrity rules as hand-written notes.
 


### PR DESCRIPTION
Closes #24.

## Summary
- **Auto-stub creation**: when an MCP write tool hits an unresolved `[[target]]`, a draft stub note is created (tags: [stub], status: draft, body backlinks to source). Authoring never blocks on chain-of-reference. Invalid id shapes still reject.
- **Suggested links**: on every write, scan the body for bare mentions of known note titles + glossary `terms`. Word-boundary, case-insensitive, strips code fences. Returns `{ target, matchedText, matchedOn, count, firstLine }` per target. Not auto-inserted.
- **Response shape**: all four write MCP tools now return `{ note, createdStubs, suggestedLinks }` instead of the bare note. The underlying `lib/vault-write.js` primitives are opt-in via `{ autoStub: true }` — default stays strict, so existing direct-callers (and the 64 existing write/section-edit assertions) keep working unchanged.
- **Stale-stub linter rule**: new `stale-stub` code flags `status: draft` + `tags: [stub]` notes whose `date` is older than `staleStubDays` (default 7). Configurable via `--stale-stub-days <n>` (CLI) and `staleStubDays` (MCP `vault_lint`).

Retrieval eval unchanged at recall@5 = 64.3% / MRR = 0.559.

## Test plan
- [x] `node test/stubs-and-suggestions.test.js` — 29/29 pass
- [x] `node test/vault-write.test.js` — 35/35 unchanged
- [x] `node test/section-edit.test.js` — 29/29 unchanged
- [x] `node test/retrieval/status_filter.test.js` — unchanged
- [x] `npx tsc --noEmit --allowJs --skipLibCheck ...` — clean
- [x] `node index.js lint --vault vault` — no issues
- [x] `node test/retrieval/eval.js` — no retrieval regression
- [ ] CI green on `feat/stubs-and-suggestions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)