### PR TITLE
feat: query-miss log for content-gap discovery (#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd web && npm install && cd ..
 
       - name: Type check (CLI)
-        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js test/section-edit.test.js test/stubs-and-suggestions.test.js
+        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js test/section-edit.test.js test/stubs-and-suggestions.test.js test/query-log.test.js
 
       - name: Type check (web)
         run: cd web && npx tsc --noEmit && cd ..
@@ -61,6 +61,9 @@ jobs:
 
       - name: Stubs + suggested-links assertions
         run: node test/stubs-and-suggestions.test.js
+
+      - name: Query-miss log assertions
+        run: node test/query-log.test.js
 
       - name: Lint web (if eslintrc exists)
         run: cd web && npm run lint 2>/dev/null || echo "No lint script defined"

--- a/index.js
+++ b/index.js
@@ -728,4 +728,83 @@ program
     }
   });
 
+// ===== QUERY LOG =====
+program
+  .command("query-log")
+  .description(
+    "Inspect the query-miss log (requires VAULT_QUERY_LOG=1 during MCP runs). " +
+      "Default view: top empty/low-score queries, grouped by normalized text."
+  )
+  .option("--misses", "List individual miss entries (chronological)")
+  .option("--top-empty", "Group misses by query text, sorted by frequency (default)")
+  .option("--tail <n>", "Print the last N entries (all, not just misses)")
+  .option("--min-score <n>", "Scores below this are treated as misses", "0.3")
+  .option("--since <date>", "Only include entries on or after YYYY-MM-DD")
+  .option("--limit <n>", "Max rows to print (default 20)", "20")
+  .option("--json", "Output as JSON")
+  .option("--clear", "Delete both active and rotated log files")
+  .action(async (options) => {
+    const vaultDir = program.opts().vault;
+    const cacheDir = path.resolve(vaultDir, "..", ".vault-cache");
+    const { readEntries, listMisses, topEmptyQueries, tailEntries, clearLog } =
+      await import("./lib/query-log.js");
+
+    if (options.clear) {
+      const removed = await clearLog(cacheDir);
+      console.log(`✓ Removed ${removed} log file(s)`);
+      return;
+    }
+
+    const entries = await readEntries(cacheDir);
+    const minScore = parseFloat(options.minScore);
+    const limit = parseInt(options.limit, 10);
+
+    if (options.tail) {
+      const n = parseInt(options.tail, 10);
+      const rows = tailEntries(entries, n);
+      if (options.json) {
+        console.log(JSON.stringify(rows, null, 2));
+      } else if (rows.length === 0) {
+        console.log("No entries logged.");
+      } else {
+        for (const e of rows) {
+          const score = typeof e.topScore === "number" ? e.topScore.toFixed(3) : "—";
+          console.log(`  ${e.timestamp}  ${e.tool}  results=${e.resultCount} top=${score}  "${e.query}"`);
+        }
+      }
+      return;
+    }
+
+    if (options.misses) {
+      const rows = listMisses(entries, { minScore, since: options.since }).slice(-limit);
+      if (options.json) {
+        console.log(JSON.stringify(rows, null, 2));
+      } else if (rows.length === 0) {
+        console.log("No misses recorded.");
+      } else {
+        for (const e of rows) {
+          const score = typeof e.topScore === "number" ? e.topScore.toFixed(3) : "—";
+          console.log(`  ${e.timestamp}  ${e.tool}  results=${e.resultCount} top=${score}  "${e.query}"`);
+        }
+      }
+      return;
+    }
+
+    const rows = topEmptyQueries(entries, { minScore, since: options.since, limit });
+    if (options.json) {
+      console.log(JSON.stringify(rows, null, 2));
+      return;
+    }
+    if (rows.length === 0) {
+      console.log("No misses recorded (or logging disabled — set VAULT_QUERY_LOG=1 during MCP runs).");
+      return;
+    }
+    console.log(`Top ${rows.length} miss queries (score threshold ${minScore}):\n`);
+    for (const r of rows) {
+      const best = r.bestTopScore === null ? "—" : r.bestTopScore.toFixed(3);
+      console.log(`  ${String(r.count).padStart(4)}×  best=${best}  "${r.query}"`);
+      console.log(`        tools: ${r.tools.join(", ")}  first: ${r.firstSeen}  last: ${r.lastSeen}`);
+    }
+  });
+
 program.parse(process.argv);

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -8,6 +8,20 @@ import path from "path";
 import { Vault } from "./vault.js";
 import { lintVault } from "./linter.js";
 import { createNote, writeNote, editSection } from "./vault-write.js";
+import { appendEntry, isLoggingEnabled } from "./query-log.js";
+
+const queryLogEnabled = isLoggingEnabled();
+async function logQuery(tool, query, results, options) {
+  if (!queryLogEnabled) return;
+  const resultCount = Array.isArray(results) ? results.length : 0;
+  let topScore = null;
+  if (resultCount > 0) {
+    const top = results[0];
+    if (typeof top.similarity === "number") topScore = top.similarity;
+    else if (typeof top.relevance === "number") topScore = top.relevance;
+  }
+  await appendEntry(cacheDir, { tool, query, resultCount, topScore, options });
+}
 
 const vaultDir = process.env.VAULT_DIR || "./vault";
 const vault = new Vault(vaultDir);
@@ -96,6 +110,7 @@ server.registerTool(
         summary,
         lastVerified,
       }));
+    await logQuery("vault_search", query, results, { limit, includeDeprecated, staleWeight });
     return {
       content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
     };
@@ -239,6 +254,16 @@ if (embeddingsDb) {
         includeDeprecated,
         staleWeight,
       });
+      await logQuery("vault_semantic_search", query, results, {
+        limit,
+        folder,
+        tag,
+        after,
+        before,
+        hyde,
+        includeDeprecated,
+        staleWeight,
+      });
       return {
         content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
       };
@@ -272,6 +297,16 @@ if (embeddingsDb) {
       }
       const results = await searchChunks(embeddingsDb, vault, query, {
         limit: limit ?? 5,
+        folder,
+        tag,
+        after,
+        before,
+        hyde,
+        includeDeprecated,
+        staleWeight,
+      });
+      await logQuery("vault_search_chunks", query, results, {
+        limit,
         folder,
         tag,
         after,
@@ -369,6 +404,18 @@ if (embeddingsDb) {
       }
       const chunks = await searchChunks(embeddingsDb, vault, query, {
         limit: limit ?? 5,
+        folder,
+        tag,
+        after,
+        before,
+        hyde,
+        includeDeprecated,
+        staleWeight,
+      });
+      await logQuery("vault_search_chunks_with_context", query, chunks, {
+        limit,
+        depth,
+        maxChars,
         folder,
         tag,
         after,

--- a/lib/query-log.js
+++ b/lib/query-log.js
@@ -1,0 +1,189 @@
+import fs from "fs/promises";
+import path from "path";
+
+/**
+ * Query-miss logging (#25).
+ *
+ * Opt-in via VAULT_QUERY_LOG=1. Every search tool appends one JSONL line
+ * with { timestamp, tool, query, resultCount, topScore, options }. The
+ * intent is to surface content gaps — queries that found nothing or
+ * nothing good — for later review. Local only; gitignored.
+ *
+ * Rotation: when the active file exceeds MAX_BYTES, rename it to
+ * `query-log.jsonl.1` and start fresh. One rotated file is kept.
+ */
+
+const MAX_BYTES = 10 * 1024 * 1024;
+const DEFAULT_MIN_SCORE = 0.3;
+
+let warnedOnFailure = false;
+function warnOnce(err) {
+  if (warnedOnFailure) return;
+  warnedOnFailure = true;
+  console.error(`[query-log] logging disabled for this session: ${err.message}`);
+}
+
+export function isLoggingEnabled(env = process.env) {
+  const v = env.VAULT_QUERY_LOG;
+  if (!v) return false;
+  const s = String(v).toLowerCase();
+  return s === "1" || s === "true" || s === "yes";
+}
+
+export function logFilePath(cacheDir) {
+  return path.join(cacheDir, "query-log.jsonl");
+}
+
+async function rotateIfNeeded(filePath) {
+  let stat;
+  try {
+    stat = await fs.stat(filePath);
+  } catch (err) {
+    if (err.code === "ENOENT") return;
+    throw err;
+  }
+  if (stat.size < MAX_BYTES) return;
+  const rotated = `${filePath}.1`;
+  try { await fs.unlink(rotated); } catch (e) { if (e.code !== "ENOENT") throw e; }
+  await fs.rename(filePath, rotated);
+}
+
+/**
+ * Append a single query entry. Never throws — errors are warned to stderr
+ * and then silenced for the remainder of the process. Search tools must
+ * keep returning results even if logging fails.
+ */
+export async function appendEntry(cacheDir, entry) {
+  try {
+    await fs.mkdir(cacheDir, { recursive: true });
+    const filePath = logFilePath(cacheDir);
+    await rotateIfNeeded(filePath);
+    const line = JSON.stringify({ timestamp: new Date().toISOString(), ...entry }) + "\n";
+    await fs.appendFile(filePath, line, "utf-8");
+  } catch (err) {
+    warnOnce(err);
+  }
+}
+
+/**
+ * Read log entries (active file + optional rotated predecessor, oldest-first).
+ * Silently skips malformed lines. Returns [] if no log exists.
+ */
+export async function readEntries(cacheDir, { includeRotated = true } = {}) {
+  const active = logFilePath(cacheDir);
+  const rotated = `${active}.1`;
+  const paths = includeRotated ? [rotated, active] : [active];
+  const entries = [];
+  for (const p of paths) {
+    let raw;
+    try {
+      raw = await fs.readFile(p, "utf-8");
+    } catch (err) {
+      if (err.code === "ENOENT") continue;
+      throw err;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        entries.push(JSON.parse(trimmed));
+      } catch {
+        // skip malformed line
+      }
+    }
+  }
+  return entries;
+}
+
+/**
+ * A "miss" is either zero results or best score below minScore.
+ */
+export function isMiss(entry, minScore = DEFAULT_MIN_SCORE) {
+  if (typeof entry.resultCount !== "number" || entry.resultCount === 0) return true;
+  if (typeof entry.topScore !== "number") return false;
+  return entry.topScore < minScore;
+}
+
+function filterSince(entries, sinceISODate) {
+  if (!sinceISODate) return entries;
+  const floor = Date.parse(sinceISODate);
+  if (Number.isNaN(floor)) return entries;
+  return entries.filter((e) => Date.parse(e.timestamp) >= floor);
+}
+
+/**
+ * Return miss entries in chronological order.
+ */
+export function listMisses(entries, { minScore = DEFAULT_MIN_SCORE, since } = {}) {
+  return filterSince(entries, since).filter((e) => isMiss(e, minScore));
+}
+
+/**
+ * Group misses by normalized query text, sorted by frequency. Normalization:
+ * trim + lowercase. Display uses the first-seen verbatim query.
+ */
+export function topEmptyQueries(entries, { minScore = DEFAULT_MIN_SCORE, since, limit = 20 } = {}) {
+  const misses = listMisses(entries, { minScore, since });
+  const groups = new Map();
+  for (const e of misses) {
+    const q = typeof e.query === "string" ? e.query : "";
+    const key = q.trim().toLowerCase();
+    if (!key) continue;
+    const g = groups.get(key);
+    if (g) {
+      g.count++;
+      g.lastSeen = e.timestamp;
+      if (typeof e.topScore === "number") g.topScores.push(e.topScore);
+      g.tools.add(e.tool);
+    } else {
+      groups.set(key, {
+        query: q.trim(),
+        count: 1,
+        firstSeen: e.timestamp,
+        lastSeen: e.timestamp,
+        topScores: typeof e.topScore === "number" ? [e.topScore] : [],
+        tools: new Set([e.tool].filter(Boolean)),
+      });
+    }
+  }
+  return [...groups.values()]
+    .map((g) => ({
+      query: g.query,
+      count: g.count,
+      firstSeen: g.firstSeen,
+      lastSeen: g.lastSeen,
+      bestTopScore: g.topScores.length ? Math.max(...g.topScores) : null,
+      tools: [...g.tools],
+    }))
+    .sort((a, b) => b.count - a.count || a.query.localeCompare(b.query))
+    .slice(0, limit);
+}
+
+export function tailEntries(entries, n = 20) {
+  if (n <= 0) return [];
+  return entries.slice(Math.max(0, entries.length - n));
+}
+
+/**
+ * Remove both active and rotated logs. Returns how many files were
+ * actually deleted.
+ */
+export async function clearLog(cacheDir) {
+  const active = logFilePath(cacheDir);
+  const rotated = `${active}.1`;
+  let removed = 0;
+  for (const p of [active, rotated]) {
+    try {
+      await fs.unlink(p);
+      removed++;
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+  return removed;
+}
+
+export const __test = {
+  MAX_BYTES,
+  DEFAULT_MIN_SCORE,
+};

--- a/test/query-log.test.js
+++ b/test/query-log.test.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Query-miss log assertions — issue #25.
+ *
+ * Exercises isLoggingEnabled toggling, appendEntry JSONL writes, rotation
+ * at MAX_BYTES, readEntries merging active + rotated, miss classification,
+ * top-query grouping, tailEntries, and clearLog.
+ */
+import fs from "fs";
+import fsp from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  isLoggingEnabled,
+  logFilePath,
+  appendEntry,
+  readEntries,
+  isMiss,
+  listMisses,
+  topEmptyQueries,
+  tailEntries,
+  clearLog,
+  __test,
+} from "../lib/query-log.js";
+
+const { MAX_BYTES, DEFAULT_MIN_SCORE } = __test;
+
+const CACHE = path.join(os.tmpdir(), `vault-qlog-${process.pid}`);
+
+function reset() {
+  if (fs.existsSync(CACHE)) fs.rmSync(CACHE, { recursive: true, force: true });
+  fs.mkdirSync(CACHE, { recursive: true });
+}
+function teardown() {
+  try { fs.rmSync(CACHE, { recursive: true, force: true }); } catch {}
+}
+
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) process.stderr.write(`  ✓ ${msg}\n`);
+  else { failed++; process.stderr.write(`  ✗ ${msg}\n`); }
+}
+
+async function main() {
+  reset();
+
+  process.stderr.write("isLoggingEnabled respects env\n");
+  assert(isLoggingEnabled({}) === false, "undefined → false");
+  assert(isLoggingEnabled({ VAULT_QUERY_LOG: "" }) === false, "empty string → false");
+  assert(isLoggingEnabled({ VAULT_QUERY_LOG: "0" }) === false, "'0' → false");
+  assert(isLoggingEnabled({ VAULT_QUERY_LOG: "1" }) === true, "'1' → true");
+  assert(isLoggingEnabled({ VAULT_QUERY_LOG: "true" }) === true, "'true' → true");
+  assert(isLoggingEnabled({ VAULT_QUERY_LOG: "YES" }) === true, "'YES' → true");
+
+  process.stderr.write("\nappendEntry writes one JSONL line per call\n");
+  reset();
+  await appendEntry(CACHE, { tool: "vault_search", query: "alpha", resultCount: 3, topScore: 0.8, options: {} });
+  await appendEntry(CACHE, { tool: "vault_search", query: "beta", resultCount: 0, topScore: null, options: { limit: 5 } });
+  const raw = await fsp.readFile(logFilePath(CACHE), "utf-8");
+  const lines = raw.trim().split("\n");
+  assert(lines.length === 2, "two lines written");
+  const parsed = lines.map((l) => JSON.parse(l));
+  assert(parsed[0].query === "alpha", "first entry's query preserved");
+  assert(parsed[0].timestamp && Date.parse(parsed[0].timestamp) > 0, "timestamp is ISO-parseable");
+  assert(parsed[1].options.limit === 5, "options round-trip through JSON");
+
+  process.stderr.write("\nreadEntries returns parsed entries oldest-first\n");
+  const entries = await readEntries(CACHE);
+  assert(entries.length === 2, "both entries read back");
+  assert(entries[0].query === "alpha" && entries[1].query === "beta", "order preserved");
+
+  process.stderr.write("\nreadEntries returns [] when no log exists\n");
+  reset();
+  const empty = await readEntries(CACHE);
+  assert(Array.isArray(empty) && empty.length === 0, "empty array when no file");
+
+  process.stderr.write("\nreadEntries skips malformed lines silently\n");
+  reset();
+  await appendEntry(CACHE, { tool: "vault_search", query: "ok", resultCount: 1, topScore: 0.5, options: {} });
+  // Append a deliberately broken line.
+  await fsp.appendFile(logFilePath(CACHE), "not-json-line\n", "utf-8");
+  await appendEntry(CACHE, { tool: "vault_search", query: "also-ok", resultCount: 0, topScore: null, options: {} });
+  const mixed = await readEntries(CACHE);
+  assert(mixed.length === 2, "malformed line skipped, good lines kept");
+  assert(mixed[0].query === "ok" && mixed[1].query === "also-ok", "good entries intact");
+
+  process.stderr.write("\nrotation: large active file is renamed to .1 on next append\n");
+  reset();
+  const active = logFilePath(CACHE);
+  // Seed active log to just over MAX_BYTES with valid JSONL so readEntries can parse it.
+  const bigEntry = JSON.stringify({
+    timestamp: "2026-04-20T00:00:00.000Z",
+    tool: "vault_search",
+    query: "seed",
+    resultCount: 0,
+    topScore: null,
+    options: {},
+    filler: "x".repeat(4096),
+  }) + "\n";
+  let buf = "";
+  while (buf.length <= MAX_BYTES) buf += bigEntry;
+  await fsp.writeFile(active, buf, "utf-8");
+  const statBefore = await fsp.stat(active);
+  assert(statBefore.size > MAX_BYTES, `seed file exceeded threshold (${statBefore.size} > ${MAX_BYTES})`);
+
+  await appendEntry(CACHE, { tool: "vault_search", query: "post-rotate", resultCount: 2, topScore: 0.9, options: {} });
+  assert(fs.existsSync(`${active}.1`), "rotated file .1 exists");
+  const newActive = await fsp.readFile(active, "utf-8");
+  assert(newActive.trim().split("\n").length === 1, "new active file has just the new entry");
+  const parsedNew = JSON.parse(newActive.trim());
+  assert(parsedNew.query === "post-rotate", "new entry in fresh active file");
+
+  process.stderr.write("\nreadEntries merges rotated + active, rotated first\n");
+  const merged = await readEntries(CACHE);
+  assert(merged.length > 1, "merged reading returns rotated + active");
+  assert(merged[merged.length - 1].query === "post-rotate", "active entry is last (newest)");
+  assert(merged[0].query === "seed", "rotated entries come first");
+
+  process.stderr.write("\nincludeRotated=false skips rotated file\n");
+  const activeOnly = await readEntries(CACHE, { includeRotated: false });
+  assert(activeOnly.length === 1 && activeOnly[0].query === "post-rotate", "active only");
+
+  process.stderr.write("\nrotation only keeps one prior file (second rotation overwrites .1)\n");
+  // Seed again — current active is just "post-rotate". Fill it past threshold.
+  await fsp.writeFile(active, buf, "utf-8");
+  await appendEntry(CACHE, { tool: "vault_search", query: "second-rotate", resultCount: 0, topScore: null, options: {} });
+  const rotatedContent = await fsp.readFile(`${active}.1`, "utf-8");
+  assert(rotatedContent.includes('"query":"seed"'), "new rotated file is the once-oversize file (second overwrite expected)");
+
+  process.stderr.write("\nisMiss classification\n");
+  assert(isMiss({ resultCount: 0 }) === true, "zero results → miss");
+  assert(isMiss({ resultCount: 3, topScore: 0.1 }) === true, "low score → miss");
+  assert(isMiss({ resultCount: 3, topScore: 0.9 }) === false, "high score → not a miss");
+  assert(isMiss({ resultCount: 3, topScore: 0.5 }, 0.9) === true, "custom threshold respected");
+  assert(isMiss({ resultCount: 5 }) === false, "results w/ no topScore is not a miss");
+  assert(DEFAULT_MIN_SCORE === 0.3, "default min score exposed for tests");
+
+  process.stderr.write("\nlistMisses + since filter\n");
+  reset();
+  const base = "2026-04-20T12:00:00.000Z";
+  // Write entries by hand via appendEntry then override timestamps by rewriting the file.
+  const sample = [
+    { timestamp: "2026-04-10T00:00:00.000Z", tool: "vault_search", query: "old-miss", resultCount: 0, topScore: null, options: {} },
+    { timestamp: "2026-04-19T00:00:00.000Z", tool: "vault_search", query: "recent-miss", resultCount: 0, topScore: null, options: {} },
+    { timestamp: "2026-04-19T00:05:00.000Z", tool: "vault_search", query: "recent-hit", resultCount: 5, topScore: 0.9, options: {} },
+    { timestamp: base, tool: "vault_search", query: "fresh-miss", resultCount: 0, topScore: null, options: {} },
+  ];
+  await fsp.writeFile(logFilePath(CACHE), sample.map((e) => JSON.stringify(e)).join("\n") + "\n", "utf-8");
+  const all = await readEntries(CACHE);
+  const misses = listMisses(all);
+  assert(misses.length === 3, "three misses total");
+  const since = listMisses(all, { since: "2026-04-18" });
+  assert(since.length === 2, "since filter drops old-miss");
+  assert(!since.some((m) => m.query === "old-miss"), "old-miss excluded");
+  assert(!since.some((m) => m.query === "recent-hit"), "hit never in misses");
+
+  process.stderr.write("\ntopEmptyQueries groups + sorts\n");
+  reset();
+  const grouped = [
+    { timestamp: "2026-04-10T00:00:00.000Z", tool: "vault_search",        query: "How do deploys work",   resultCount: 0, topScore: null, options: {} },
+    { timestamp: "2026-04-11T00:00:00.000Z", tool: "vault_semantic_search", query: "how do deploys work", resultCount: 0, topScore: null, options: {} },
+    { timestamp: "2026-04-12T00:00:00.000Z", tool: "vault_search",        query: "  HOW DO DEPLOYS WORK  ", resultCount: 0, topScore: null, options: {} },
+    { timestamp: "2026-04-10T00:00:00.000Z", tool: "vault_search",        query: "rare question",         resultCount: 0, topScore: null, options: {} },
+    { timestamp: "2026-04-12T00:00:00.000Z", tool: "vault_search",        query: "not a miss",            resultCount: 5, topScore: 0.9, options: {} },
+  ];
+  await fsp.writeFile(logFilePath(CACHE), grouped.map((e) => JSON.stringify(e)).join("\n") + "\n", "utf-8");
+  const entries2 = await readEntries(CACHE);
+  const top = topEmptyQueries(entries2, { limit: 10 });
+  assert(top.length === 2, "two distinct miss groups (case+whitespace normalized)");
+  assert(top[0].count === 3, "most-frequent group counted thrice");
+  assert(top[0].query === "How do deploys work", "display uses first-seen verbatim query");
+  assert(top[0].tools.includes("vault_search") && top[0].tools.includes("vault_semantic_search"), "tools aggregated across entries");
+  assert(top[0].firstSeen < top[0].lastSeen, "firstSeen < lastSeen when multiple entries");
+
+  process.stderr.write("\ntopEmptyQueries honors minScore\n");
+  reset();
+  const mixedScored = [
+    { timestamp: "2026-04-10T00:00:00.000Z", tool: "vault_search", query: "borderline", resultCount: 1, topScore: 0.25, options: {} },
+    { timestamp: "2026-04-11T00:00:00.000Z", tool: "vault_search", query: "borderline", resultCount: 1, topScore: 0.25, options: {} },
+    { timestamp: "2026-04-12T00:00:00.000Z", tool: "vault_search", query: "strong",     resultCount: 5, topScore: 0.85, options: {} },
+  ];
+  await fsp.writeFile(logFilePath(CACHE), mixedScored.map((e) => JSON.stringify(e)).join("\n") + "\n", "utf-8");
+  const entries3 = await readEntries(CACHE);
+  const strictTop = topEmptyQueries(entries3, { minScore: 0.3, limit: 10 });
+  assert(strictTop.length === 1 && strictTop[0].query === "borderline", "0.3 threshold flags borderline");
+  const looserTop = topEmptyQueries(entries3, { minScore: 0.1, limit: 10 });
+  assert(looserTop.length === 0, "0.1 threshold hides the borderline misses");
+  assert(strictTop[0].bestTopScore !== null, "bestTopScore propagated");
+
+  process.stderr.write("\ntailEntries returns last N\n");
+  const entries4 = await readEntries(CACHE);
+  const tail2 = tailEntries(entries4, 2);
+  assert(tail2.length === 2, "tail returns at most n entries");
+  assert(tail2[tail2.length - 1].query === "strong", "last entry is newest");
+  assert(tailEntries(entries4, 0).length === 0, "tail 0 returns empty");
+  assert(tailEntries(entries4, 99).length === entries4.length, "tail > length returns all");
+
+  process.stderr.write("\nclearLog deletes both files\n");
+  reset();
+  await appendEntry(CACHE, { tool: "vault_search", query: "a", resultCount: 0, topScore: null, options: {} });
+  await fsp.writeFile(`${logFilePath(CACHE)}.1`, "junk\n", "utf-8");
+  const removed = await clearLog(CACHE);
+  assert(removed === 2, "both active and rotated removed");
+  assert(!fs.existsSync(logFilePath(CACHE)), "active gone");
+  assert(!fs.existsSync(`${logFilePath(CACHE)}.1`), "rotated gone");
+  const noop = await clearLog(CACHE);
+  assert(noop === 0, "clearLog is idempotent");
+
+  process.stderr.write("\nappendEntry never throws: bogus path swallows error\n");
+  const bogus = "/this/should/not/be/a/writable/path/xyz";
+  let threw = false;
+  try {
+    await appendEntry(bogus, { tool: "vault_search", query: "q", resultCount: 0, topScore: null, options: {} });
+  } catch {
+    threw = true;
+  }
+  assert(!threw, "appendEntry catches filesystem errors");
+
+  teardown();
+  if (failed > 0) {
+    process.stderr.write(`\n✗ ${failed} assertion(s) failed\n`);
+    process.exit(1);
+  }
+  process.stderr.write("\n✓ All query-log assertions passed.\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  teardown();
+  process.exit(1);
+});

--- a/vault/README.md
+++ b/vault/README.md
@@ -130,6 +130,23 @@ Draft stubs that haven't been filled in after **`staleStubDays`** (default 7) ar
 
 Use these to keep agent-authored content subject to the same schema and link-integrity rules as hand-written notes.
 
+## Query-miss log (content-gap discovery)
+
+Turn on with `VAULT_QUERY_LOG=1` in the MCP env. Every call to the four search tools (`vault_search`, `vault_semantic_search`, `vault_search_chunks`, `vault_search_chunks_with_context`) appends one JSONL line to `.vault-cache/query-log.jsonl` with `{ timestamp, tool, query, resultCount, topScore, options }`. Off by default, local-only, gitignored. Rotates at 10 MB — one rotated file (`.jsonl.1`) kept.
+
+The intent: surface queries that found nothing or nothing good, so you can see what content the vault is missing.
+
+Inspect with the CLI:
+
+- `claude-code-vault query-log` — top empty/low-score queries grouped by normalized text
+- `claude-code-vault query-log --misses` — chronological miss entries
+- `claude-code-vault query-log --tail 20` — last N entries (all, not just misses)
+- `claude-code-vault query-log --min-score 0.2` — tune the "nothing good" threshold (default 0.3)
+- `claude-code-vault query-log --since 2026-04-01` — only recent entries
+- `claude-code-vault query-log --clear` — delete both the active and rotated log
+
+Logging failures are warned once to stderr then silenced for the rest of the process — search results never block on disk I/O.
+
 ## Starting a new project
 
 1. `mkdir vault/new-project/`


### PR DESCRIPTION
Closes #25.

## Summary

- New `lib/query-log.js` module with `appendEntry`, rotation at 10 MB (one rotated file kept), `readEntries`, `isMiss`, `listMisses`, `topEmptyQueries`, `tailEntries`, `clearLog`.
- All four MCP search tools (`vault_search`, `vault_semantic_search`, `vault_search_chunks`, `vault_search_chunks_with_context`) append one JSONL line per call: `{ timestamp, tool, query, resultCount, topScore, options }`.
- Opt-in: set `VAULT_QUERY_LOG=1` in the MCP env. Off by default, local-only — `.vault-cache/` is already gitignored.
- New CLI `claude-code-vault query-log` with `--misses`, `--tail <n>`, `--min-score <n>` (default 0.3), `--since YYYY-MM-DD`, `--limit <n>`, `--json`, `--clear`. Default view groups misses by normalized query text, sorted by frequency.
- Logging failures warn once to stderr then go silent for the rest of the process — search results never block on disk I/O.
- 50 assertions in `test/query-log.test.js`, wired into CI.

## Design notes

- "Miss" = `resultCount === 0` OR `topScore < minScore` (default 0.3). Tunable per-call.
- Normalization for grouping: `trim + lowercase`. Display uses the first-seen verbatim query so casing survives.
- `options` captured per-tool: `limit`, `folder`, `tag`, `after`, `before`, `hyde`, `includeDeprecated`, `staleWeight`, plus `depth`/`maxChars` for the context variant.

## Test plan

- [x] `node test/query-log.test.js` — 50 assertions pass (env toggling, JSONL writes, rotation at MAX_BYTES, readEntries merges rotated+active, isMiss classification, since/minScore filters, grouping + sort, tailEntries, clearLog idempotency, bogus-path swallow)
- [x] `node test/vault-write.test.js`, `node test/section-edit.test.js`, `node test/stubs-and-suggestions.test.js`, `node test/retrieval/status_filter.test.js` — all green
- [x] `node index.js lint --vault vault` — clean
- [x] `node test/retrieval/eval.js` — recall@5 = 64.3%, MRR = 0.559 (no regression)
- [x] `npx tsc --noEmit --allowJs --skipLibCheck` — clean
- [x] `node index.js query-log --help` — CLI surfaces as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)