### PR TITLE
feat: vault gap CLI for repo coverage analysis (closes #26)

### DIFF
--- a/index.js
+++ b/index.js
@@ -728,6 +728,44 @@ program
     }
   });
 
+// ===== GAP =====
+program
+  .command("gap <repo-path>")
+  .description(
+    "Report host-repo surfaces (src modules, routes, schemas, scripts) with no vault mention. " +
+      "Honors .gitignore via `git ls-files`."
+  )
+  .option("--json", "Output as JSON instead of markdown")
+  .action(async (repoPath, options) => {
+    const vaultDir = program.opts().vault;
+    const vault = new Vault(vaultDir);
+    await vault.reindex();
+
+    const { analyzeGaps, formatMarkdown } = await import("./lib/gap-analyzer.js");
+    const resolvedRepo = path.resolve(repoPath);
+
+    try {
+      await fs.access(resolvedRepo);
+    } catch {
+      console.error(`✗ Repo path not found: ${resolvedRepo}`);
+      process.exit(1);
+    }
+
+    let report;
+    try {
+      report = await analyzeGaps(vault, resolvedRepo);
+    } catch (err) {
+      console.error(`✗ Gap analysis failed: ${err.message}`);
+      process.exit(1);
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      process.stdout.write(formatMarkdown(report));
+    }
+  });
+
 // ===== QUERY LOG =====
 program
   .command("query-log")

--- a/index.js
+++ b/index.js
@@ -20,12 +20,22 @@ program
   .version(pkg.version)
   .option("--vault <dir>", "Vault directory", "./vault");
 
+// Resolution order: explicit --vault flag > VAULT_DIR env > default "./vault".
+// Commander's getOptionValueSource lets us distinguish "user passed --vault"
+// from "default kicked in", so env-var can win over the default without
+// overriding an explicitly-passed flag.
+function resolveVaultDir() {
+  const source = program.getOptionValueSource?.("vault");
+  if (source === "cli") return program.opts().vault;
+  return process.env.VAULT_DIR || program.opts().vault;
+}
+
 // ===== INIT =====
 program
   .command("init [project]")
   .description("Initialize a new vault project")
   .action(async (projectName) => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const project = projectName || path.basename(process.cwd());
     const projectPath = path.join(vaultDir, project);
 
@@ -167,7 +177,7 @@ program
   .command("index")
   .description("Reindex vault and list notes")
   .action(async () => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const vault = new Vault(vaultDir);
     await vault.reindex();
     console.log(`✓ Indexed ${vault.index.length} notes\n`);
@@ -188,7 +198,7 @@ program
   .option("--json", "Output as JSON")
   .description("Search vault")
   .action(async (query, options) => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const vault = new Vault(vaultDir);
     await vault.reindex();
 
@@ -217,7 +227,7 @@ program
   .command("list [tag]")
   .description("List notes, optionally filtered by tag")
   .action(async (tag) => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const vault = new Vault(vaultDir);
     await vault.reindex();
 
@@ -233,7 +243,7 @@ program
   .command("export [format]")
   .description("Export vault as JSON or markdown")
   .action(async (format = "json") => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const vault = new Vault(vaultDir);
     await vault.reindex();
 
@@ -257,7 +267,7 @@ program
   .option("--stale-days <n>", "Stale threshold in days for lastVerified", "180")
   .option("--stale-stub-days <n>", "Age (days) at which draft stubs are flagged", "7")
   .action(async (options) => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const vault = new Vault(vaultDir);
     await vault.reindex();
 
@@ -288,7 +298,7 @@ program
   .command("stats")
   .description("Show vault statistics")
   .action(async () => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const vault = new Vault(vaultDir);
     await vault.reindex();
 
@@ -338,7 +348,7 @@ program
   )
   .description("Create a new note")
   .action(async (pathStr, title, options) => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const slug = title
       .toLowerCase()
       .replace(/[^\w\s-]/g, "")
@@ -386,7 +396,7 @@ program
   .option("--dry-run", "Don't modify files")
   .description("Auto-fix frontmatter in all notes (date normalization, missing description, trailing whitespace)")
   .action(async (options) => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const vault = new Vault(vaultDir);
     await vault.reindex();
 
@@ -456,7 +466,7 @@ program
   .option("--dry-run", "Don't push to remote")
   .description("Git add, commit, and push vault changes")
   .action(async (options) => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
 
     const statusResult = spawnSync("git", ["status", "--porcelain", vaultDir], {
       encoding: "utf-8",
@@ -498,7 +508,7 @@ program
   .description("Start the web server")
   .action(async (options) => {
     process.env.PORT = options.port;
-    process.env.VAULT_DIR = program.opts().vault;
+    process.env.VAULT_DIR = resolveVaultDir();
     await import("./lib/server.js");
   });
 
@@ -507,7 +517,7 @@ program
   .command("mcp")
   .description("Start the MCP server (stdio transport, for Claude Code)")
   .action(async () => {
-    process.env.VAULT_DIR = program.opts().vault;
+    process.env.VAULT_DIR = resolveVaultDir();
     await import("./lib/mcp.js");
   });
 
@@ -516,7 +526,7 @@ async function openSyncedDb() {
   const { openEmbeddingsDb, syncEmbeddings } = await import(
     "./lib/embeddings.js"
   );
-  const vaultDir = program.opts().vault;
+  const vaultDir = resolveVaultDir();
   const vault = new Vault(vaultDir);
   await vault.reindex();
 
@@ -755,7 +765,7 @@ program
       process.exit(1);
     }
 
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const vault = new Vault(vaultDir);
     await vault.reindex();
 
@@ -792,7 +802,7 @@ program
   .option("--json", "Output as JSON")
   .option("--clear", "Delete both active and rotated log files")
   .action(async (options) => {
-    const vaultDir = program.opts().vault;
+    const vaultDir = resolveVaultDir();
     const cacheDir = path.resolve(vaultDir, "..", ".vault-cache");
     const { readEntries, listMisses, topEmptyQueries, tailEntries, clearLog } =
       await import("./lib/query-log.js");

--- a/index.js
+++ b/index.js
@@ -738,19 +738,28 @@ program
   )
   .option("--json", "Output as JSON (includes covered/mentioned/uncovered arrays) instead of markdown")
   .action(async (repoPath, options) => {
-    const vaultDir = program.opts().vault;
-    const vault = new Vault(vaultDir);
-    await vault.reindex();
-
-    const { analyzeGaps, formatMarkdown } = await import("./lib/gap-analyzer.js");
     const resolvedRepo = path.resolve(repoPath);
 
+    // Cheap existence + repo-shape checks BEFORE the vault reindex so users
+    // don't pay the reindex cost on a typo or a non-git directory.
     try {
       await fs.access(resolvedRepo);
     } catch {
       console.error(`✗ Repo path not found: ${resolvedRepo}`);
       process.exit(1);
     }
+    try {
+      await fs.access(path.join(resolvedRepo, ".git"));
+    } catch {
+      console.error(`✗ Not a git repository: ${resolvedRepo}`);
+      process.exit(1);
+    }
+
+    const vaultDir = program.opts().vault;
+    const vault = new Vault(vaultDir);
+    await vault.reindex();
+
+    const { analyzeGaps, formatMarkdown } = await import("./lib/gap-analyzer.js");
 
     let report;
     try {

--- a/index.js
+++ b/index.js
@@ -732,10 +732,11 @@ program
 program
   .command("gap <repo-path>")
   .description(
-    "Report host-repo surfaces (src modules, routes, schemas, scripts) with no vault mention. " +
+    "Classify host-repo surfaces (src modules, routes, schemas, scripts) into " +
+      "uncovered / mentioned-in-prose / covered buckets relative to the vault. " +
       "Honors .gitignore via `git ls-files`."
   )
-  .option("--json", "Output as JSON instead of markdown")
+  .option("--json", "Output as JSON (includes covered/mentioned/uncovered arrays) instead of markdown")
   .action(async (repoPath, options) => {
     const vaultDir = program.opts().vault;
     const vault = new Vault(vaultDir);

--- a/lib/gap-analyzer.js
+++ b/lib/gap-analyzer.js
@@ -6,15 +6,24 @@ import { spawnSync } from "child_process";
  * Repo → vault gap analyzer (issue #26).
  *
  * Identifies "significant surfaces" in a host repo (top-level `src/` subdirs,
- * route-declaring files, schema files, package.json scripts) and reports which
- * ones have **no** corresponding vault mention (note id, title, tag, or
- * wiki-link target). Surfaces are sorted by recency of last `git log` touch so
- * the most actively-churning undocumented areas float to the top.
+ * route-declaring files, schema files, package.json scripts) and bucketizes
+ * them into three coverage tiers relative to the vault:
+ *
+ *   - `covered`   — surface name appears in a note id, title, tag, or
+ *                   wiki-link target ("strong" documentation signal).
+ *   - `mentioned` — surface name appears somewhere in a note body but NOT in
+ *                   any structural slot above. Prose-only coverage: the topic
+ *                   is discussed but doesn't have a dedicated note.
+ *   - `uncovered` — zero mentions anywhere in the vault, including bodies.
+ *                   These are the true priority gaps.
+ *
+ * Surfaces are sorted by recency of last `git log` touch so the most actively-
+ * churning under-documented areas float to the top.
  *
  * Conservative by design: uses `git ls-files` to respect `.gitignore`, plain
- * substring matching against a normalized haystack of all vault surface tokens,
- * and simple regex heuristics for route/schema detection. False negatives are
- * preferable to false positives — a noisy gap report is worse than a terse one.
+ * substring matching against normalized haystacks, and simple regex heuristics
+ * for route/schema detection. Short tokens (<3 chars) are skipped to avoid
+ * false positives.
  */
 
 const ROUTE_PATTERNS = [
@@ -191,8 +200,9 @@ export function normalizeToken(s) {
 /**
  * Build a single normalized haystack string covering vault note ids, titles,
  * tags, and wiki-link targets. Substring matching against this string is the
- * conservative coverage test: if the surface name (normalized) appears
- * anywhere, it's considered documented.
+ * strong-signal coverage test: if the surface name (normalized) appears
+ * anywhere in this haystack, the surface has a dedicated note / structural
+ * mention in the vault.
  */
 export function buildVaultHaystack(vault) {
   const parts = [];
@@ -206,8 +216,32 @@ export function buildVaultHaystack(vault) {
 }
 
 /**
- * Surface is "covered" iff its normalized name has a non-trivial substring
- * match in the haystack. Names shorter than 3 chars are skipped (too noisy).
+ * Build a normalized haystack of vault note *bodies* only (the markdown
+ * content minus frontmatter). Used to detect "mentioned in prose" coverage —
+ * surfaces whose name shows up in text but not in any structural slot.
+ *
+ * Reads files on-demand from disk; vault.index doesn't carry body text.
+ */
+export async function buildVaultBodyHaystack(vault) {
+  const parts = [];
+  for (const note of vault.index) {
+    try {
+      const abs = path.join(vault.vaultDir, note.path);
+      const raw = await fs.readFile(abs, "utf-8");
+      const fmMatch = raw.match(/^---\n[\s\S]*?\n---\n/);
+      const body = fmMatch ? raw.slice(fmMatch[0].length) : raw;
+      parts.push(normalizeToken(body));
+    } catch {
+      // unreadable note — skip silently; the structural haystack still covers it
+    }
+  }
+  return parts.filter(Boolean).join(" | ");
+}
+
+/**
+ * Surface is "covered" (strong signal) iff its normalized name has a
+ * non-trivial substring match in the structural haystack. Names shorter than
+ * 3 chars are skipped (too noisy).
  */
 export function surfaceIsCovered(surface, haystack) {
   const token = normalizeToken(surface.name);
@@ -216,43 +250,133 @@ export function surfaceIsCovered(surface, haystack) {
 }
 
 /**
- * Main entry: produce the gap report.
- *   { repo, generatedAt, surfaces: [...], gaps: [...] }
- * Each gap: { kind, name, path, mtime, covered: false }
- * Gaps are sorted by mtime descending (most recently touched first), with
- * null mtimes last.
+ * Surface is "mentioned" (weak signal) iff its normalized name appears in the
+ * body haystack. Short tokens are skipped on the same rationale.
+ */
+export function surfaceIsMentioned(surface, bodyHaystack) {
+  const token = normalizeToken(surface.name);
+  if (!token || token.length < 3) return false;
+  return bodyHaystack.includes(token);
+}
+
+/**
+ * Classify a surface into one of three coverage tiers:
+ *   "covered"   — strong structural match (title/id/tag/wiki-link)
+ *   "mentioned" — prose match only (body text, no dedicated note)
+ *   "uncovered" — no match anywhere
+ */
+export function classifySurface(surface, structuralHaystack, bodyHaystack) {
+  if (surfaceIsCovered(surface, structuralHaystack)) return "covered";
+  if (surfaceIsMentioned(surface, bodyHaystack)) return "mentioned";
+  return "uncovered";
+}
+
+/**
+ * Main entry: produce the gap report with three coverage tiers.
+ *
+ * Return shape:
+ *   {
+ *     repo, generatedAt,
+ *     surfaces: [...],   // all surfaces, each with a `coverage` field
+ *     covered:   [...],  // surfaces with coverage === "covered"
+ *     mentioned: [...],  // surfaces with coverage === "mentioned"
+ *     uncovered: [...],  // surfaces with coverage === "uncovered"
+ *     missing:   [...],  // alias for uncovered (back-compat with earlier shape)
+ *     gaps:      [...],  // alias for uncovered (back-compat with earlier shape)
+ *   }
+ *
+ * Each surface now has: { kind, name, path, mtime, coverage, covered }.
+ * (`covered` boolean kept for back-compat; `coverage` is the new tier string.)
+ *
+ * Each tier bucket is sorted by mtime descending (most recently touched first),
+ * with null mtimes last.
  */
 export async function analyzeGaps(vault, repoPath, opts = {}) {
   const files = opts.files ?? listGitFiles(repoPath);
   const surfaces = await detectSurfaces(repoPath, files);
-  const haystack = buildVaultHaystack(vault);
+  const structuralHaystack = buildVaultHaystack(vault);
+  const bodyHaystack = await buildVaultBodyHaystack(vault);
 
   const enriched = surfaces.map((s) => {
     const mtime = s.kind === "script" ? null : lastCommitISO(repoPath, s.path);
-    return { ...s, mtime, covered: surfaceIsCovered(s, haystack) };
+    const coverage = classifySurface(s, structuralHaystack, bodyHaystack);
+    return {
+      ...s,
+      mtime,
+      coverage,
+      covered: coverage === "covered",
+    };
   });
 
-  const gaps = enriched
-    .filter((s) => !s.covered)
-    .sort((a, b) => {
-      if (a.mtime && b.mtime) return a.mtime < b.mtime ? 1 : a.mtime > b.mtime ? -1 : 0;
-      if (a.mtime) return -1;
-      if (b.mtime) return 1;
-      return a.name.localeCompare(b.name);
-    });
+  const sortByRecency = (a, b) => {
+    if (a.mtime && b.mtime) {
+      if (a.mtime < b.mtime) return 1;
+      if (a.mtime > b.mtime) return -1;
+      return 0;
+    }
+    if (a.mtime) return -1;
+    if (b.mtime) return 1;
+    return a.name.localeCompare(b.name);
+  };
+
+  const covered = enriched.filter((s) => s.coverage === "covered").sort(sortByRecency);
+  const mentioned = enriched.filter((s) => s.coverage === "mentioned").sort(sortByRecency);
+  const uncovered = enriched.filter((s) => s.coverage === "uncovered").sort(sortByRecency);
 
   return {
     repo: path.resolve(repoPath),
     generatedAt: new Date().toISOString(),
     surfaces: enriched,
-    gaps,
+    covered,
+    mentioned,
+    uncovered,
+    missing: uncovered,
+    gaps: uncovered,
   };
 }
 
+function groupByKind(rows) {
+  const byKind = new Map();
+  for (const r of rows) {
+    if (!byKind.has(r.kind)) byKind.set(r.kind, []);
+    byKind.get(r.kind).push(r);
+  }
+  return byKind;
+}
+
+const KIND_TITLES = {
+  "src-module": "Source modules",
+  "route-file": "Route files",
+  "schema-file": "Schema files",
+  script: "Package scripts",
+};
+const KIND_ORDER = ["src-module", "route-file", "schema-file", "script"];
+
+function renderKindSections(lines, rows) {
+  const byKind = groupByKind(rows);
+  for (const kind of KIND_ORDER) {
+    const kindRows = byKind.get(kind);
+    if (!kindRows || kindRows.length === 0) continue;
+    lines.push(`### ${KIND_TITLES[kind] || kind} (${kindRows.length})`);
+    lines.push("");
+    for (const row of kindRows) {
+      const when = row.mtime ? row.mtime.slice(0, 10) : "—";
+      lines.push(`- [${when}] \`${row.name}\` — ${row.path}`);
+    }
+    lines.push("");
+  }
+}
+
 /**
- * Format the report as a markdown document suitable for stdout or file
- * output. Groups by surface kind, shows the last-touched timestamp, and
- * includes a short summary line at the top.
+ * Format the report as a markdown document with three coverage sections.
+ *
+ * - `## Uncovered (no mentions)` — top priority: zero presence in the vault,
+ *   worth writing a dedicated note.
+ * - `## Mentioned in prose (no dedicated note)` — second priority: the topic
+ *   appears in body text but nothing promotes it to a title/tag/link, so
+ *   retrieval and graph queries miss it. Candidates for promotion.
+ * - `## Covered` — count only by default (collapse-friendly). Included so the
+ *   denominator is visible.
  */
 export function formatMarkdown(report) {
   const lines = [];
@@ -261,42 +385,59 @@ export function formatMarkdown(report) {
   lines.push(`- **Repo**: \`${report.repo}\``);
   lines.push(`- **Generated**: ${report.generatedAt}`);
   lines.push(`- **Surfaces scanned**: ${report.surfaces.length}`);
-  lines.push(`- **Gaps (no vault mention)**: ${report.gaps.length}`);
+  lines.push(`- **Uncovered**: ${report.uncovered.length}`);
+  lines.push(`- **Mentioned (prose only)**: ${report.mentioned.length}`);
+  lines.push(`- **Covered**: ${report.covered.length}`);
   lines.push("");
 
-  if (report.gaps.length === 0) {
-    lines.push(`_No gaps detected — every significant surface has at least one vault mention._`);
+  if (report.surfaces.length === 0) {
+    lines.push(`_No surfaces detected in the host repo._`);
     lines.push("");
     return lines.join("\n");
   }
 
-  const byKind = new Map();
-  for (const g of report.gaps) {
-    if (!byKind.has(g.kind)) byKind.set(g.kind, []);
-    byKind.get(g.kind).push(g);
+  if (report.uncovered.length === 0 && report.mentioned.length === 0) {
+    lines.push(
+      `_Every significant surface has at least a dedicated vault note. Nice._`
+    );
+    lines.push("");
+    return lines.join("\n");
   }
 
-  const kindTitles = {
-    "src-module": "Source modules",
-    "route-file": "Route files",
-    "schema-file": "Schema files",
-    script: "Package scripts",
-  };
-
-  const kindOrder = ["src-module", "route-file", "schema-file", "script"];
-  for (const kind of kindOrder) {
-    const rows = byKind.get(kind);
-    if (!rows || rows.length === 0) continue;
-    lines.push(`## ${kindTitles[kind] || kind} (${rows.length})`);
+  lines.push(`## Uncovered (no mentions)`);
+  lines.push("");
+  if (report.uncovered.length === 0) {
+    lines.push(`_None — every surface appears somewhere in the vault._`);
     lines.push("");
-    for (const row of rows) {
-      const when = row.mtime ? row.mtime.slice(0, 10) : "—";
-      lines.push(`- [${when}] \`${row.name}\` — ${row.path}`);
-    }
+  } else {
+    lines.push(
+      `_Top priority: no vault note mentions these at all. Consider writing a dedicated note._`
+    );
     lines.push("");
+    renderKindSections(lines, report.uncovered);
   }
 
-  lines.push(`_Sorted by last git commit touching the surface path (most recent first)._`);
+  lines.push(`## Mentioned in prose (no dedicated note)`);
+  lines.push("");
+  if (report.mentioned.length === 0) {
+    lines.push(`_None — every surface that appears in prose also has a title/tag/link entry._`);
+    lines.push("");
+  } else {
+    lines.push(
+      `_Second priority: these appear in note bodies but have no dedicated note, tag, or wiki-link target. Retrieval and graph queries likely miss them. Consider promoting to their own note._`
+    );
+    lines.push("");
+    renderKindSections(lines, report.mentioned);
+  }
+
+  lines.push(`## Covered (${report.covered.length})`);
+  lines.push("");
+  lines.push(
+    `_These surfaces have at least one note id / title / tag / wiki-link match. Full list omitted — pass \`--json\` for detail._`
+  );
+  lines.push("");
+
+  lines.push(`_Each section sorted by last git commit touching the surface path (most recent first)._`);
   lines.push("");
   return lines.join("\n");
 }

--- a/lib/gap-analyzer.js
+++ b/lib/gap-analyzer.js
@@ -39,6 +39,32 @@ const SCHEMA_DIR_RE = /(^|\/)(migrations|migration|prisma|db\/migrate|schema)\//
 const ROUTE_CANDIDATE_EXT_RE = /\.(js|jsx|ts|tsx|mjs|cjs|py|rb|go|java|kt|rs|php)$/i;
 
 /**
+ * Generated / vendored directories whose contents are never interesting
+ * surfaces to bucketize. Path is `split("/")` so we check the first segment
+ * for module detection and also substring-match the full path for route
+ * candidates.
+ */
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  "out",
+  "vendor",
+  ".vault-cache",
+]);
+
+/** True iff any path segment matches SKIP_DIRS. */
+function pathIsInSkipDir(rel) {
+  const parts = rel.split("/");
+  for (const part of parts) {
+    if (SKIP_DIRS.has(part)) return true;
+  }
+  return false;
+}
+
+/**
  * Run `git ls-files` inside `repoPath` and return the tracked paths (relative
  * to repoPath). Honors `.gitignore` automatically. Throws if the directory
  * isn't a git repo or git isn't available — callers should handle that.
@@ -62,9 +88,12 @@ export function listGitFiles(repoPath) {
 }
 
 /**
- * For a given relative file path inside repoPath, return the unix-ish ISO
- * timestamp of its last commit (`git log -1 --format=%cI -- <path>`), or
- * `null` if git has no history for the file (freshly added, untracked, etc).
+ * For a given relative file path inside repoPath, return the ISO timestamp of
+ * its last commit (`git log -1 --format=%cI -- <path>`), or `null` if git has
+ * no history for the file (freshly added, untracked, etc).
+ *
+ * Kept for single-path lookups and back-compat. `analyzeGaps` uses the
+ * batched `buildMtimeMap` instead to avoid O(N) git spawns per surface.
  */
 export function lastCommitISO(repoPath, relFile) {
   const result = spawnSync(
@@ -75,6 +104,42 @@ export function lastCommitISO(repoPath, relFile) {
   if (result.status !== 0) return null;
   const out = (result.stdout || "").trim();
   return out.length > 0 ? out : null;
+}
+
+/**
+ * Build a Map<relPath, isoTimestamp> of each tracked file's last-touched
+ * commit in ONE git invocation.
+ *
+ * Approach: `git log --name-only --format=%cI` streams the repo history in
+ * commit order (newest first). Each commit block is an ISO timestamp line
+ * followed by the relative paths touched. We fold that stream into a map,
+ * keeping only the first (newest) timestamp seen per path. This replaces
+ * per-surface `git log -1 --` calls which were O(surfaces) spawnSyncs on the
+ * hot path — painful on large repos.
+ *
+ * Returns an empty map if the repo has zero commits, if git fails, or if
+ * repoPath isn't a repo (the CLI guards against that separately).
+ */
+export function buildMtimeMap(repoPath) {
+  const result = spawnSync(
+    "git",
+    ["log", "--name-only", "--format=%cI"],
+    { cwd: repoPath, encoding: "utf-8", maxBuffer: 100 * 1024 * 1024 }
+  );
+  if (result.status !== 0) return new Map();
+  const out = result.stdout || "";
+  const map = new Map();
+  let currentIso = null;
+  for (const line of out.split("\n")) {
+    if (line.length === 0) continue;
+    // ISO 8601: starts with 4-digit year + dash.
+    if (/^\d{4}-\d{2}-\d{2}T/.test(line)) {
+      currentIso = line;
+      continue;
+    }
+    if (currentIso && !map.has(line)) map.set(line, currentIso);
+  }
+  return map;
 }
 
 /**
@@ -97,9 +162,95 @@ async function safeReadHead(absPath, maxBytes = 256 * 1024) {
   }
 }
 
+/**
+ * Strip single-line `//` comments and block `/* ... *\/` comments from the
+ * head of the file before regex matching. Not a full parser — string literals
+ * containing `//` will be miscounted — but catches the common false-positive
+ * cases (JSDoc examples, commented-out code) where someone writes
+ * `// app.get('/foo', ...)` in a file that declares no live routes.
+ */
+function stripComments(content) {
+  if (!content) return "";
+  // Block comments first so nested `//` inside them aren't preserved.
+  let stripped = content.replaceAll(/\/\*[\s\S]*?\*\//g, "");
+  // Single-line comments: drop from `//` to end of line.
+  stripped = stripped.replaceAll(/\/\/[^\n]*/g, "");
+  return stripped;
+}
+
 function fileDeclaresRoute(content) {
   if (!content) return false;
-  return ROUTE_PATTERNS.some((re) => re.test(content));
+  const code = stripComments(content);
+  return ROUTE_PATTERNS.some((re) => re.test(code));
+}
+
+/**
+ * Scan tracked file paths for top-level src/ subdirectories and schema files
+ * in one pass. Returns { srcModules, schemaSurfaces } — schema surfaces are
+ * ready to push as-is; srcModules is a Map<name, representativePath>.
+ */
+function scanPathsForSrcAndSchemas(files) {
+  const srcModules = new Map();
+  const schemaSurfaces = [];
+  for (const rel of files) {
+    if (pathIsInSkipDir(rel)) continue;
+    const parts = rel.split("/");
+    if (parts.length >= 3 && parts[0] === "src") {
+      const name = parts[1];
+      if (!srcModules.has(name)) srcModules.set(name, rel);
+    }
+    if (SCHEMA_FILE_RE.test(rel) || SCHEMA_DIR_RE.test(rel)) {
+      schemaSurfaces.push({
+        kind: "schema-file",
+        name: path.basename(rel),
+        path: rel,
+        mtime: null,
+      });
+    }
+  }
+  return { srcModules, schemaSurfaces };
+}
+
+/**
+ * Read each candidate file's head and push route-file surfaces for those
+ * whose non-comment content matches ROUTE_PATTERNS.
+ */
+async function detectRouteSurfaces(repoPath, files) {
+  const surfaces = [];
+  const routeCandidates = files.filter(
+    (f) => ROUTE_CANDIDATE_EXT_RE.test(f) && !pathIsInSkipDir(f)
+  );
+  for (const rel of routeCandidates) {
+    const abs = path.join(repoPath, rel);
+    const head = await safeReadHead(abs);
+    if (fileDeclaresRoute(head)) {
+      surfaces.push({ kind: "route-file", name: rel, path: rel, mtime: null });
+    }
+  }
+  return surfaces;
+}
+
+/**
+ * Parse package.json (if tracked) and emit a script-kind surface per entry in
+ * `scripts`. Malformed JSON returns an empty list rather than throwing.
+ */
+async function detectScriptSurfaces(repoPath, files) {
+  const pkgRel = files.find((f) => f === "package.json");
+  if (!pkgRel) return [];
+  try {
+    const raw = await fs.readFile(path.join(repoPath, pkgRel), "utf-8");
+    const pkg = JSON.parse(raw);
+    const scripts = pkg.scripts || {};
+    return Object.keys(scripts).map((scriptName) => ({
+      kind: "script",
+      name: scriptName,
+      path: `package.json#scripts.${scriptName}`,
+      mtime: null,
+    }));
+  } catch {
+    // malformed package.json — skip silently
+    return [];
+  }
 }
 
 /**
@@ -111,68 +262,23 @@ function fileDeclaresRoute(content) {
  *   mtime: last commit ISO timestamp, or null
  */
 export async function detectSurfaces(repoPath, files) {
-  const surfaces = [];
-  const srcModules = new Map(); // name -> representative file path
-
-  for (const rel of files) {
-    const parts = rel.split("/");
-
-    // Top-level src/<subdir>/... — represent the subdir as a single surface.
-    if (parts.length >= 3 && parts[0] === "src") {
-      const name = parts[1];
-      if (!srcModules.has(name)) srcModules.set(name, rel);
-    }
-
-    if (SCHEMA_FILE_RE.test(rel) || SCHEMA_DIR_RE.test(rel)) {
-      surfaces.push({
-        kind: "schema-file",
-        name: path.basename(rel),
-        path: rel,
-        mtime: null,
-      });
-    }
-  }
-
-  for (const [name, repPath] of srcModules) {
-    surfaces.push({ kind: "src-module", name, path: repPath, mtime: null });
-  }
-
-  // Route detection — only scan files whose extension looks like source code.
-  const routeCandidates = files.filter((f) => ROUTE_CANDIDATE_EXT_RE.test(f));
-  for (const rel of routeCandidates) {
-    const abs = path.join(repoPath, rel);
-    const head = await safeReadHead(abs);
-    if (fileDeclaresRoute(head)) {
-      surfaces.push({
-        kind: "route-file",
-        name: rel,
-        path: rel,
-        mtime: null,
-      });
-    }
-  }
-
-  // package.json scripts.
-  const pkgRel = files.find((f) => f === "package.json");
-  if (pkgRel) {
-    try {
-      const raw = await fs.readFile(path.join(repoPath, pkgRel), "utf-8");
-      const pkg = JSON.parse(raw);
-      const scripts = pkg.scripts || {};
-      for (const scriptName of Object.keys(scripts)) {
-        surfaces.push({
-          kind: "script",
-          name: scriptName,
-          path: `package.json#scripts.${scriptName}`,
-          mtime: null,
-        });
-      }
-    } catch {
-      // malformed package.json — skip silently
-    }
-  }
-
-  return dedupeSurfaces(surfaces);
+  const { srcModules, schemaSurfaces } = scanPathsForSrcAndSchemas(files);
+  const srcSurfaces = [...srcModules].map(([name, repPath]) => ({
+    kind: "src-module",
+    name,
+    path: repPath,
+    mtime: null,
+  }));
+  const [routeSurfaces, scriptSurfaces] = await Promise.all([
+    detectRouteSurfaces(repoPath, files),
+    detectScriptSurfaces(repoPath, files),
+  ]);
+  return dedupeSurfaces([
+    ...schemaSurfaces,
+    ...srcSurfaces,
+    ...routeSurfaces,
+    ...scriptSurfaces,
+  ]);
 }
 
 function dedupeSurfaces(surfaces) {
@@ -198,65 +304,75 @@ export function normalizeToken(s) {
 }
 
 /**
- * Build a single normalized haystack string covering vault note ids, titles,
- * tags, and wiki-link targets. Substring matching against this string is the
- * strong-signal coverage test: if the surface name (normalized) appears
- * anywhere in this haystack, the surface has a dedicated note / structural
- * mention in the vault.
+ * Build a per-note array of normalized haystack strings covering each note's
+ * id, title, tags, and wiki-link targets. Returning one entry per note (rather
+ * than a single joined string) prevents multi-word surface tokens like
+ * `"auth login"` from spuriously matching text that straddles two adjacent
+ * notes — the cross-note bleed that a `join(" | ")` approach can't avoid
+ * because `|` normalizes to whitespace.
+ *
+ * Used with `surfaceIsCovered(surface, notes)` which does
+ * `notes.some(n => n.includes(token))`.
  */
 export function buildVaultHaystack(vault) {
-  const parts = [];
+  const notes = [];
   for (const note of vault.index) {
-    parts.push(normalizeToken(note.id));
-    parts.push(normalizeToken(note.title));
-    for (const tag of note.tags || []) parts.push(normalizeToken(tag));
-    for (const link of note.links || []) parts.push(normalizeToken(link));
+    const parts = [
+      normalizeToken(note.id),
+      normalizeToken(note.title),
+      ...(note.tags || []).map(normalizeToken),
+      ...(note.links || []).map(normalizeToken),
+    ];
+    const joined = parts.filter(Boolean).join(" ");
+    if (joined) notes.push(joined);
   }
-  return parts.filter(Boolean).join(" | ");
+  return notes;
 }
 
 /**
- * Build a normalized haystack of vault note *bodies* only (the markdown
- * content minus frontmatter). Used to detect "mentioned in prose" coverage —
- * surfaces whose name shows up in text but not in any structural slot.
+ * Per-note array of normalized vault note *body* haystacks (markdown content
+ * minus frontmatter), one string per note. Same bleed-avoidance rationale as
+ * buildVaultHaystack.
  *
  * Reads files on-demand from disk; vault.index doesn't carry body text.
  */
 export async function buildVaultBodyHaystack(vault) {
-  const parts = [];
+  const notes = [];
   for (const note of vault.index) {
     try {
       const abs = path.join(vault.vaultDir, note.path);
       const raw = await fs.readFile(abs, "utf-8");
       const fmMatch = raw.match(/^---\n[\s\S]*?\n---\n/);
       const body = fmMatch ? raw.slice(fmMatch[0].length) : raw;
-      parts.push(normalizeToken(body));
+      const normalized = normalizeToken(body);
+      if (normalized) notes.push(normalized);
     } catch {
       // unreadable note — skip silently; the structural haystack still covers it
     }
   }
-  return parts.filter(Boolean).join(" | ");
+  return notes;
 }
 
 /**
- * Surface is "covered" (strong signal) iff its normalized name has a
- * non-trivial substring match in the structural haystack. Names shorter than
- * 3 chars are skipped (too noisy).
+ * Surface is "covered" (strong signal) iff its normalized name appears as a
+ * substring in at least one note's structural haystack. Per-note matching
+ * prevents cross-note bleed (see buildVaultHaystack). Names shorter than 3
+ * chars are skipped (too noisy).
  */
-export function surfaceIsCovered(surface, haystack) {
+export function surfaceIsCovered(surface, notes) {
   const token = normalizeToken(surface.name);
   if (!token || token.length < 3) return false;
-  return haystack.includes(token);
+  return notes.some((note) => note.includes(token));
 }
 
 /**
- * Surface is "mentioned" (weak signal) iff its normalized name appears in the
- * body haystack. Short tokens are skipped on the same rationale.
+ * Surface is "mentioned" (weak signal) iff its normalized name appears as a
+ * substring in at least one note's body haystack. Short tokens skipped.
  */
-export function surfaceIsMentioned(surface, bodyHaystack) {
+export function surfaceIsMentioned(surface, bodyNotes) {
   const token = normalizeToken(surface.name);
   if (!token || token.length < 3) return false;
-  return bodyHaystack.includes(token);
+  return bodyNotes.some((note) => note.includes(token));
 }
 
 /**
@@ -296,9 +412,12 @@ export async function analyzeGaps(vault, repoPath, opts = {}) {
   const surfaces = await detectSurfaces(repoPath, files);
   const structuralHaystack = buildVaultHaystack(vault);
   const bodyHaystack = await buildVaultBodyHaystack(vault);
+  // Batched: one `git log --name-only --format=%cI` instead of per-surface
+  // `git log -1 -- <path>` spawns. See buildMtimeMap JSDoc for the approach.
+  const mtimeMap = buildMtimeMap(repoPath);
 
   const enriched = surfaces.map((s) => {
-    const mtime = s.kind === "script" ? null : lastCommitISO(repoPath, s.path);
+    const mtime = s.kind === "script" ? null : mtimeMap.get(s.path) || null;
     const coverage = classifySurface(s, structuralHaystack, bodyHaystack);
     return {
       ...s,

--- a/lib/gap-analyzer.js
+++ b/lib/gap-analyzer.js
@@ -1,0 +1,302 @@
+import fs from "fs/promises";
+import path from "path";
+import { spawnSync } from "child_process";
+
+/**
+ * Repo → vault gap analyzer (issue #26).
+ *
+ * Identifies "significant surfaces" in a host repo (top-level `src/` subdirs,
+ * route-declaring files, schema files, package.json scripts) and reports which
+ * ones have **no** corresponding vault mention (note id, title, tag, or
+ * wiki-link target). Surfaces are sorted by recency of last `git log` touch so
+ * the most actively-churning undocumented areas float to the top.
+ *
+ * Conservative by design: uses `git ls-files` to respect `.gitignore`, plain
+ * substring matching against a normalized haystack of all vault surface tokens,
+ * and simple regex heuristics for route/schema detection. False negatives are
+ * preferable to false positives — a noisy gap report is worse than a terse one.
+ */
+
+const ROUTE_PATTERNS = [
+  /\bapp\.(get|post|put|patch|delete|head|options|use|all)\s*\(/,
+  /\brouter\.(get|post|put|patch|delete|head|options|use|all)\s*\(/,
+  /\b(fastify|server)\.(get|post|put|patch|delete|head|options|route)\s*\(/,
+  /@(Get|Post|Put|Patch|Delete|Head|Options|Route|RequestMapping|GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping)\s*\(/,
+  /\bcreateRouter\s*\(/,
+];
+
+const SCHEMA_FILE_RE = /(^|\/)(schema\.prisma|schema\.sql|.*\.sql)$/i;
+const SCHEMA_DIR_RE = /(^|\/)(migrations|migration|prisma|db\/migrate|schema)\//i;
+const ROUTE_CANDIDATE_EXT_RE = /\.(js|jsx|ts|tsx|mjs|cjs|py|rb|go|java|kt|rs|php)$/i;
+
+/**
+ * Run `git ls-files` inside `repoPath` and return the tracked paths (relative
+ * to repoPath). Honors `.gitignore` automatically. Throws if the directory
+ * isn't a git repo or git isn't available — callers should handle that.
+ */
+export function listGitFiles(repoPath) {
+  const result = spawnSync("git", ["ls-files", "-z"], {
+    cwd: repoPath,
+    encoding: "buffer",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  if (result.error) {
+    throw new Error(`git ls-files failed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr ? result.stderr.toString("utf-8") : "";
+    throw new Error(`git ls-files exited ${result.status}: ${stderr.trim()}`);
+  }
+  const raw = result.stdout.toString("utf-8");
+  if (!raw) return [];
+  return raw.split("\0").filter((s) => s.length > 0);
+}
+
+/**
+ * For a given relative file path inside repoPath, return the unix-ish ISO
+ * timestamp of its last commit (`git log -1 --format=%cI -- <path>`), or
+ * `null` if git has no history for the file (freshly added, untracked, etc).
+ */
+export function lastCommitISO(repoPath, relFile) {
+  const result = spawnSync(
+    "git",
+    ["log", "-1", "--format=%cI", "--", relFile],
+    { cwd: repoPath, encoding: "utf-8" }
+  );
+  if (result.status !== 0) return null;
+  const out = (result.stdout || "").trim();
+  return out.length > 0 ? out : null;
+}
+
+/**
+ * Quick file read that returns empty string on failure (binary files,
+ * permissions, etc). Limits to the first ~256 KB because route declarations
+ * are always near the top; no need to slurp megabyte bundles.
+ */
+async function safeReadHead(absPath, maxBytes = 256 * 1024) {
+  try {
+    const fh = await fs.open(absPath, "r");
+    try {
+      const buf = Buffer.alloc(maxBytes);
+      const { bytesRead } = await fh.read(buf, 0, maxBytes, 0);
+      return buf.slice(0, bytesRead).toString("utf-8");
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return "";
+  }
+}
+
+function fileDeclaresRoute(content) {
+  if (!content) return false;
+  return ROUTE_PATTERNS.some((re) => re.test(content));
+}
+
+/**
+ * Walk the tracked file list and return significant surfaces.
+ * Surface shape: { kind, name, path, mtime }
+ *   kind: "src-module" | "route-file" | "schema-file" | "script"
+ *   name: human-readable identifier used for matching + display
+ *   path: representative repo-relative path (or script name)
+ *   mtime: last commit ISO timestamp, or null
+ */
+export async function detectSurfaces(repoPath, files) {
+  const surfaces = [];
+  const srcModules = new Map(); // name -> representative file path
+
+  for (const rel of files) {
+    const parts = rel.split("/");
+
+    // Top-level src/<subdir>/... — represent the subdir as a single surface.
+    if (parts.length >= 3 && parts[0] === "src") {
+      const name = parts[1];
+      if (!srcModules.has(name)) srcModules.set(name, rel);
+    }
+
+    if (SCHEMA_FILE_RE.test(rel) || SCHEMA_DIR_RE.test(rel)) {
+      surfaces.push({
+        kind: "schema-file",
+        name: path.basename(rel),
+        path: rel,
+        mtime: null,
+      });
+    }
+  }
+
+  for (const [name, repPath] of srcModules) {
+    surfaces.push({ kind: "src-module", name, path: repPath, mtime: null });
+  }
+
+  // Route detection — only scan files whose extension looks like source code.
+  const routeCandidates = files.filter((f) => ROUTE_CANDIDATE_EXT_RE.test(f));
+  for (const rel of routeCandidates) {
+    const abs = path.join(repoPath, rel);
+    const head = await safeReadHead(abs);
+    if (fileDeclaresRoute(head)) {
+      surfaces.push({
+        kind: "route-file",
+        name: rel,
+        path: rel,
+        mtime: null,
+      });
+    }
+  }
+
+  // package.json scripts.
+  const pkgRel = files.find((f) => f === "package.json");
+  if (pkgRel) {
+    try {
+      const raw = await fs.readFile(path.join(repoPath, pkgRel), "utf-8");
+      const pkg = JSON.parse(raw);
+      const scripts = pkg.scripts || {};
+      for (const scriptName of Object.keys(scripts)) {
+        surfaces.push({
+          kind: "script",
+          name: scriptName,
+          path: `package.json#scripts.${scriptName}`,
+          mtime: null,
+        });
+      }
+    } catch {
+      // malformed package.json — skip silently
+    }
+  }
+
+  return dedupeSurfaces(surfaces);
+}
+
+function dedupeSurfaces(surfaces) {
+  const seen = new Map();
+  for (const s of surfaces) {
+    const key = `${s.kind}::${s.name}`;
+    if (!seen.has(key)) seen.set(key, s);
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Normalize a token for conservative substring matching: lowercase, strip
+ * path extension, replace non-alphanumeric with spaces, collapse whitespace.
+ */
+export function normalizeToken(s) {
+  if (!s) return "";
+  return String(s)
+    .toLowerCase()
+    .replace(/\.[a-z0-9]+$/i, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/**
+ * Build a single normalized haystack string covering vault note ids, titles,
+ * tags, and wiki-link targets. Substring matching against this string is the
+ * conservative coverage test: if the surface name (normalized) appears
+ * anywhere, it's considered documented.
+ */
+export function buildVaultHaystack(vault) {
+  const parts = [];
+  for (const note of vault.index) {
+    parts.push(normalizeToken(note.id));
+    parts.push(normalizeToken(note.title));
+    for (const tag of note.tags || []) parts.push(normalizeToken(tag));
+    for (const link of note.links || []) parts.push(normalizeToken(link));
+  }
+  return parts.filter(Boolean).join(" | ");
+}
+
+/**
+ * Surface is "covered" iff its normalized name has a non-trivial substring
+ * match in the haystack. Names shorter than 3 chars are skipped (too noisy).
+ */
+export function surfaceIsCovered(surface, haystack) {
+  const token = normalizeToken(surface.name);
+  if (!token || token.length < 3) return false;
+  return haystack.includes(token);
+}
+
+/**
+ * Main entry: produce the gap report.
+ *   { repo, generatedAt, surfaces: [...], gaps: [...] }
+ * Each gap: { kind, name, path, mtime, covered: false }
+ * Gaps are sorted by mtime descending (most recently touched first), with
+ * null mtimes last.
+ */
+export async function analyzeGaps(vault, repoPath, opts = {}) {
+  const files = opts.files ?? listGitFiles(repoPath);
+  const surfaces = await detectSurfaces(repoPath, files);
+  const haystack = buildVaultHaystack(vault);
+
+  const enriched = surfaces.map((s) => {
+    const mtime = s.kind === "script" ? null : lastCommitISO(repoPath, s.path);
+    return { ...s, mtime, covered: surfaceIsCovered(s, haystack) };
+  });
+
+  const gaps = enriched
+    .filter((s) => !s.covered)
+    .sort((a, b) => {
+      if (a.mtime && b.mtime) return a.mtime < b.mtime ? 1 : a.mtime > b.mtime ? -1 : 0;
+      if (a.mtime) return -1;
+      if (b.mtime) return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+  return {
+    repo: path.resolve(repoPath),
+    generatedAt: new Date().toISOString(),
+    surfaces: enriched,
+    gaps,
+  };
+}
+
+/**
+ * Format the report as a markdown document suitable for stdout or file
+ * output. Groups by surface kind, shows the last-touched timestamp, and
+ * includes a short summary line at the top.
+ */
+export function formatMarkdown(report) {
+  const lines = [];
+  lines.push(`# Vault Gap Report`);
+  lines.push("");
+  lines.push(`- **Repo**: \`${report.repo}\``);
+  lines.push(`- **Generated**: ${report.generatedAt}`);
+  lines.push(`- **Surfaces scanned**: ${report.surfaces.length}`);
+  lines.push(`- **Gaps (no vault mention)**: ${report.gaps.length}`);
+  lines.push("");
+
+  if (report.gaps.length === 0) {
+    lines.push(`_No gaps detected — every significant surface has at least one vault mention._`);
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  const byKind = new Map();
+  for (const g of report.gaps) {
+    if (!byKind.has(g.kind)) byKind.set(g.kind, []);
+    byKind.get(g.kind).push(g);
+  }
+
+  const kindTitles = {
+    "src-module": "Source modules",
+    "route-file": "Route files",
+    "schema-file": "Schema files",
+    script: "Package scripts",
+  };
+
+  const kindOrder = ["src-module", "route-file", "schema-file", "script"];
+  for (const kind of kindOrder) {
+    const rows = byKind.get(kind);
+    if (!rows || rows.length === 0) continue;
+    lines.push(`## ${kindTitles[kind] || kind} (${rows.length})`);
+    lines.push("");
+    for (const row of rows) {
+      const when = row.mtime ? row.mtime.slice(0, 10) : "—";
+      lines.push(`- [${when}] \`${row.name}\` — ${row.path}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(`_Sorted by last git commit touching the surface path (most recent first)._`);
+  lines.push("");
+  return lines.join("\n");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-vault",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-vault",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^4.1.0",

--- a/test/gap-analyzer.test.js
+++ b/test/gap-analyzer.test.js
@@ -14,12 +14,15 @@ import path from "path";
 import { spawnSync } from "child_process";
 import {
   analyzeGaps,
+  buildVaultBodyHaystack,
   buildVaultHaystack,
+  classifySurface,
   detectSurfaces,
   formatMarkdown,
   listGitFiles,
   normalizeToken,
   surfaceIsCovered,
+  surfaceIsMentioned,
 } from "../lib/gap-analyzer.js";
 import { Vault } from "../lib/vault.js";
 
@@ -216,6 +219,29 @@ async function buildVaultFixture({ covers }) {
     );
   }
 
+  // If requested, add a note whose body MENTIONS `billing` in prose but
+  // whose title/tags/links never use the word — exactly the "mentioned in
+  // prose" case we want to distinguish from both uncovered and covered.
+  if (covers.includes("billing-prose")) {
+    await writeFile(
+      projectDir,
+      "designs/payments-overview.md",
+      [
+        "---",
+        "title: Payments overview",
+        "tags: [payments, commerce]",
+        "date: 2026-04-20",
+        "---",
+        "",
+        "# Payments overview",
+        "",
+        "We integrate Stripe for checkout. The billing flow is described",
+        "informally here but does not have its own dedicated note yet.",
+        "",
+      ].join("\n")
+    );
+  }
+
   const vault = new Vault(vaultRoot);
   await vault.reindex();
   return vault;
@@ -259,7 +285,9 @@ async function main() {
   assert(JSON.stringify(scripts) === JSON.stringify(["build", "deploy:prod", "test"]), "package.json scripts detected");
 
   process.stderr.write("\nbuildVaultHaystack + surfaceIsCovered substring match\n");
-  const vault = await buildVaultFixture({ covers: ["auth", "schema", "build"] });
+  const vault = await buildVaultFixture({
+    covers: ["auth", "schema", "build", "billing-prose"],
+  });
   const haystack = buildVaultHaystack(vault);
   assert(haystack.includes("auth"), "haystack mentions auth");
   assert(haystack.includes("schema"), "haystack mentions schema");
@@ -269,34 +297,103 @@ async function main() {
   assert(surfaceIsCovered({ kind: "script", name: "deploy:prod" }, haystack) === false, "deploy:prod NOT covered");
   assert(surfaceIsCovered({ kind: "src-module", name: "ab" }, haystack) === false, "too-short token skipped");
 
-  process.stderr.write("\nanalyzeGaps produces sorted gap list\n");
+  process.stderr.write("\nbuildVaultBodyHaystack + surfaceIsMentioned prose match\n");
+  const bodyHaystack = await buildVaultBodyHaystack(vault);
+  assert(bodyHaystack.includes("billing"), "body haystack mentions billing (prose-only)");
+  assert(
+    surfaceIsMentioned({ kind: "src-module", name: "billing" }, bodyHaystack) === true,
+    "billing prose-mentioned"
+  );
+  assert(
+    surfaceIsMentioned({ kind: "src-module", name: "inventory" }, bodyHaystack) === false,
+    "inventory NOT even prose-mentioned"
+  );
+  assert(
+    surfaceIsCovered({ kind: "src-module", name: "billing" }, haystack) === false,
+    "billing NOT in structural haystack (only prose)"
+  );
+
+  process.stderr.write("\nclassifySurface tiers\n");
+  assert(
+    classifySurface({ kind: "src-module", name: "auth" }, haystack, bodyHaystack) === "covered",
+    "auth → covered (structural)"
+  );
+  assert(
+    classifySurface({ kind: "src-module", name: "billing" }, haystack, bodyHaystack) === "mentioned",
+    "billing → mentioned (prose only)"
+  );
+  assert(
+    classifySurface({ kind: "src-module", name: "inventory" }, haystack, bodyHaystack) === "uncovered",
+    "inventory → uncovered (nowhere)"
+  );
+
+  process.stderr.write("\nanalyzeGaps produces three-tier report\n");
   const report = await analyzeGaps(vault, repo);
   assert(report.repo === path.resolve(repo), "report carries resolved repo path");
   assert(Array.isArray(report.surfaces) && report.surfaces.length > 0, "surfaces array populated");
-  assert(Array.isArray(report.gaps), "gaps is an array");
-  const gapNames = report.gaps.map((g) => `${g.kind}::${g.name}`);
-  assert(gapNames.includes("src-module::inventory"), "inventory module flagged as gap");
-  assert(gapNames.includes("src-module::billing"), "billing module flagged as gap");
-  assert(gapNames.includes("script::deploy:prod"), "deploy:prod script flagged as gap");
-  assert(!gapNames.includes("src-module::auth"), "auth module NOT flagged (covered)");
-  assert(!gapNames.includes("script::build"), "build script NOT flagged (covered)");
+  assert(Array.isArray(report.covered), "covered is an array");
+  assert(Array.isArray(report.mentioned), "mentioned is an array");
+  assert(Array.isArray(report.uncovered), "uncovered is an array");
+  assert(Array.isArray(report.gaps), "gaps alias preserved");
+  assert(Array.isArray(report.missing), "missing alias preserved");
+  assert(report.gaps === report.uncovered, "gaps alias points at uncovered");
+  assert(report.missing === report.uncovered, "missing alias points at uncovered");
 
-  // Sorting: non-null mtime gaps should precede null-mtime gaps (scripts).
-  const firstScriptIdx = report.gaps.findIndex((g) => g.kind === "script");
-  const firstSrcIdx = report.gaps.findIndex((g) => g.kind !== "script" && g.mtime);
-  if (firstScriptIdx >= 0 && firstSrcIdx >= 0) {
-    assert(firstSrcIdx < firstScriptIdx, "mtime-ful surfaces come before null-mtime scripts");
+  const asKey = (s) => `${s.kind}::${s.name}`;
+  const coveredNames = new Set(report.covered.map(asKey));
+  const mentionedNames = new Set(report.mentioned.map(asKey));
+  const uncoveredNames = new Set(report.uncovered.map(asKey));
+
+  assert(coveredNames.has("src-module::auth"), "auth in covered");
+  assert(coveredNames.has("script::build"), "build in covered");
+  assert(mentionedNames.has("src-module::billing"), "billing in mentioned (prose only)");
+  assert(!coveredNames.has("src-module::billing"), "billing NOT in covered");
+  assert(!uncoveredNames.has("src-module::billing"), "billing NOT in uncovered");
+  assert(uncoveredNames.has("src-module::inventory"), "inventory in uncovered");
+  assert(uncoveredNames.has("script::deploy:prod"), "deploy:prod in uncovered");
+
+  // Every surface has a coverage tier, and the booleans agree.
+  for (const s of report.surfaces) {
+    assert(
+      s.coverage === "covered" || s.coverage === "mentioned" || s.coverage === "uncovered",
+      `surface ${s.name} has valid coverage tier (${s.coverage})`
+    );
+    assert(s.covered === (s.coverage === "covered"), `surface ${s.name} covered bool matches tier`);
   }
 
-  process.stderr.write("\nformatMarkdown includes sections and counts\n");
+  // Sorting: within uncovered, non-null mtime surfaces precede null-mtime scripts.
+  const firstScriptIdx = report.uncovered.findIndex((g) => g.kind === "script");
+  const firstSrcIdx = report.uncovered.findIndex((g) => g.kind !== "script" && g.mtime);
+  if (firstScriptIdx >= 0 && firstSrcIdx >= 0) {
+    assert(firstSrcIdx < firstScriptIdx, "mtime-ful uncovered surfaces precede null-mtime scripts");
+  }
+
+  process.stderr.write("\nformatMarkdown renders three coverage tiers\n");
   const md = formatMarkdown(report);
   assert(md.startsWith("# Vault Gap Report"), "markdown starts with title");
   assert(md.includes("**Repo**"), "markdown lists repo");
-  assert(md.includes("**Gaps (no vault mention)**"), "markdown summarizes gap count");
-  assert(md.includes("Source modules"), "markdown has src-module section");
-  assert(md.includes("inventory"), "markdown lists inventory gap");
+  assert(md.includes("**Uncovered**:"), "markdown shows uncovered count");
+  assert(md.includes("**Mentioned (prose only)**:"), "markdown shows mentioned count");
+  assert(md.includes("**Covered**:"), "markdown shows covered count");
+  assert(md.includes("## Uncovered (no mentions)"), "markdown has Uncovered section");
+  assert(md.includes("## Mentioned in prose"), "markdown has Mentioned section");
+  assert(md.includes("## Covered"), "markdown has Covered section");
+  assert(md.includes("Source modules"), "markdown has src-module subsection");
+  assert(md.includes("inventory"), "markdown lists inventory uncovered");
+  // billing is mentioned in prose, so it should appear under Mentioned but
+  // not under Uncovered.
+  const uncoveredBlock = md.slice(
+    md.indexOf("## Uncovered"),
+    md.indexOf("## Mentioned")
+  );
+  const mentionedBlock = md.slice(
+    md.indexOf("## Mentioned"),
+    md.indexOf("## Covered")
+  );
+  assert(!uncoveredBlock.includes("`billing`"), "billing NOT listed under Uncovered");
+  assert(mentionedBlock.includes("`billing`"), "billing listed under Mentioned");
 
-  process.stderr.write("\nformatMarkdown handles zero-gap case\n");
+  process.stderr.write("\nformatMarkdown handles zero-uncovered / zero-mentioned case\n");
   const fullCoverVault = await buildVaultFixture({
     covers: ["auth", "schema", "build"],
   });
@@ -321,23 +418,48 @@ async function main() {
   const vaultFull = new Vault(vaultRoot2);
   await vaultFull.reindex();
   const fullReport = await analyzeGaps(vaultFull, repo);
-  // Not guaranteed to hit zero (some tokens like "users" route file full path
-  // may still miss), so just assert the happy-path empty format doesn't crash:
-  const fullMd = formatMarkdown({
+  // Force an empty-tiers render and assert it renders cleanly.
+  const emptyMd = formatMarkdown({
     ...fullReport,
+    uncovered: [],
+    mentioned: [],
     gaps: [],
+    missing: [],
   });
-  assert(fullMd.includes("No gaps detected"), "empty-gap report renders cleanly");
+  assert(
+    emptyMd.includes("Every significant surface has at least a dedicated vault note"),
+    "empty-tier report renders cleanly"
+  );
   // Keep the lint clean:
   void fullCoverVault;
 
-  process.stderr.write("\nJSON shape matches contract\n");
+  process.stderr.write("\nJSON shape matches three-tier contract\n");
   const parsed = JSON.parse(JSON.stringify(report));
   assert(typeof parsed.generatedAt === "string", "generatedAt is a string");
   assert(Array.isArray(parsed.surfaces), "surfaces array present");
-  for (const g of parsed.gaps) {
-    assert(typeof g.kind === "string" && typeof g.name === "string", `gap has kind+name (${g.kind})`);
-    assert(g.covered === false, `gap.covered always false (${g.name})`);
+  assert(Array.isArray(parsed.covered), "covered array present in JSON");
+  assert(Array.isArray(parsed.mentioned), "mentioned array present in JSON");
+  assert(Array.isArray(parsed.uncovered), "uncovered array present in JSON");
+  assert(Array.isArray(parsed.gaps), "gaps alias present in JSON");
+  assert(Array.isArray(parsed.missing), "missing alias present in JSON");
+  for (const s of parsed.surfaces) {
+    assert(typeof s.kind === "string" && typeof s.name === "string", `surface has kind+name (${s.kind})`);
+    assert(
+      s.coverage === "covered" || s.coverage === "mentioned" || s.coverage === "uncovered",
+      `surface.coverage is one of the three tiers (${s.name} → ${s.coverage})`
+    );
+  }
+  for (const u of parsed.uncovered) {
+    assert(u.coverage === "uncovered", `uncovered entry tagged uncovered (${u.name})`);
+    assert(u.covered === false, `uncovered.covered === false (${u.name})`);
+  }
+  for (const m of parsed.mentioned) {
+    assert(m.coverage === "mentioned", `mentioned entry tagged mentioned (${m.name})`);
+    assert(m.covered === false, `mentioned.covered === false (${m.name})`);
+  }
+  for (const c of parsed.covered) {
+    assert(c.coverage === "covered", `covered entry tagged covered (${c.name})`);
+    assert(c.covered === true, `covered.covered === true (${c.name})`);
   }
 
   process.stderr.write("\nlistGitFiles on non-repo throws\n");

--- a/test/gap-analyzer.test.js
+++ b/test/gap-analyzer.test.js
@@ -289,8 +289,9 @@ async function main() {
     covers: ["auth", "schema", "build", "billing-prose"],
   });
   const haystack = buildVaultHaystack(vault);
-  assert(haystack.includes("auth"), "haystack mentions auth");
-  assert(haystack.includes("schema"), "haystack mentions schema");
+  assert(Array.isArray(haystack), "haystack is per-note array");
+  assert(haystack.some((n) => n.includes("auth")), "haystack mentions auth");
+  assert(haystack.some((n) => n.includes("schema")), "haystack mentions schema");
   assert(surfaceIsCovered({ kind: "src-module", name: "auth" }, haystack) === true, "auth src module covered");
   assert(surfaceIsCovered({ kind: "src-module", name: "inventory" }, haystack) === false, "inventory NOT covered");
   assert(surfaceIsCovered({ kind: "script", name: "build" }, haystack) === true, "build script covered");
@@ -299,7 +300,8 @@ async function main() {
 
   process.stderr.write("\nbuildVaultBodyHaystack + surfaceIsMentioned prose match\n");
   const bodyHaystack = await buildVaultBodyHaystack(vault);
-  assert(bodyHaystack.includes("billing"), "body haystack mentions billing (prose-only)");
+  assert(Array.isArray(bodyHaystack), "bodyHaystack is per-note array");
+  assert(bodyHaystack.some((n) => n.includes("billing")), "body haystack mentions billing (prose-only)");
   assert(
     surfaceIsMentioned({ kind: "src-module", name: "billing" }, bodyHaystack) === true,
     "billing prose-mentioned"
@@ -472,6 +474,166 @@ async function main() {
     threw = true;
   }
   assert(threw, "non-repo path rejected");
+
+  process.stderr.write("\nper-note haystack prevents cross-note bleed\n");
+  // Construct a vault with TWO notes where joining them with " | " (the old
+  // approach) would accidentally let "auth login" match text spanning the
+  // boundary: note A ends with "auth", note B starts with "login". With
+  // per-note matching, neither note alone contains "auth login", so a
+  // surface named "auth login" must NOT be classified as covered.
+  const bleedVaultRoot = setupDirs("bleed-vault");
+  const bleedProj = path.join(bleedVaultRoot, "proj");
+  fs.mkdirSync(bleedProj, { recursive: true });
+  await writeFile(
+    bleedProj,
+    "a-auth.md",
+    ["---", "title: Something auth", "date: 2026-04-20", "---", "", "# Auth", ""].join("\n")
+  );
+  await writeFile(
+    bleedProj,
+    "b-login.md",
+    ["---", "title: Login flow", "date: 2026-04-20", "---", "", "# Login flow", ""].join("\n")
+  );
+  const bleedVault = new Vault(bleedVaultRoot);
+  await bleedVault.reindex();
+  const bleedHaystack = buildVaultHaystack(bleedVault);
+  assert(
+    surfaceIsCovered({ kind: "src-module", name: "auth login" }, bleedHaystack) === false,
+    "multi-word surface does NOT bleed across adjacent notes"
+  );
+  assert(
+    surfaceIsCovered({ kind: "src-module", name: "auth" }, bleedHaystack) === true,
+    "single-word surface still matches within one note"
+  );
+  assert(
+    surfaceIsCovered({ kind: "src-module", name: "login" }, bleedHaystack) === true,
+    "other single-word surface still matches within its note"
+  );
+
+  process.stderr.write("\nempty vault (no notes) → all surfaces uncovered\n");
+  const emptyVaultRoot = setupDirs("empty-vault");
+  fs.mkdirSync(path.join(emptyVaultRoot, "proj"), { recursive: true });
+  const emptyVault = new Vault(emptyVaultRoot);
+  await emptyVault.reindex();
+  // Should not throw, should produce a report, should have all surfaces as uncovered.
+  const emptyReport = await analyzeGaps(emptyVault, repo);
+  assert(Array.isArray(emptyReport.uncovered), "empty vault analyze produced uncovered array");
+  assert(emptyReport.covered.length === 0, "empty vault: no surfaces covered");
+  assert(emptyReport.mentioned.length === 0, "empty vault: no surfaces mentioned");
+  assert(
+    emptyReport.uncovered.length === emptyReport.surfaces.length,
+    "empty vault: every surface in uncovered"
+  );
+
+  process.stderr.write("\nmalformed package.json does not crash, yields zero scripts\n");
+  const badPkgRepo = setupDirs("bad-pkg-repo");
+  run("git", ["init", "-q"], badPkgRepo);
+  run("git", ["config", "user.email", "test@example.com"], badPkgRepo);
+  run("git", ["config", "user.name", "test"], badPkgRepo);
+  run("git", ["config", "commit.gpgsign", "false"], badPkgRepo);
+  await writeFile(badPkgRepo, "package.json", "{ this is not valid json ");
+  await writeFile(badPkgRepo, "src/thing/x.js", "export function x() {}\n");
+  run("git", ["add", "-A"], badPkgRepo);
+  run("git", ["commit", "-q", "-m", "initial"], badPkgRepo);
+  const badPkgFiles = listGitFiles(badPkgRepo);
+  const badPkgSurfaces = await detectSurfaces(badPkgRepo, badPkgFiles);
+  const badPkgScripts = badPkgSurfaces.filter((s) => s.kind === "script");
+  assert(badPkgScripts.length === 0, "malformed package.json yields zero script surfaces");
+  assert(
+    badPkgSurfaces.some((s) => s.kind === "src-module" && s.name === "thing"),
+    "malformed package.json does not prevent src-module detection"
+  );
+
+  process.stderr.write("\nzero-commit git repo → empty files list, not a throw\n");
+  const emptyRepo = setupDirs("empty-repo");
+  run("git", ["init", "-q"], emptyRepo);
+  run("git", ["config", "user.email", "test@example.com"], emptyRepo);
+  run("git", ["config", "user.name", "test"], emptyRepo);
+  const emptyFiles = listGitFiles(emptyRepo);
+  assert(Array.isArray(emptyFiles), "zero-commit repo returned array");
+  assert(emptyFiles.length === 0, "zero-commit repo returned empty array");
+
+  process.stderr.write("\ndetectSurfaces skips generated dirs (dist/ etc)\n");
+  const skipRepo = setupDirs("skip-dirs-repo");
+  run("git", ["init", "-q"], skipRepo);
+  run("git", ["config", "user.email", "test@example.com"], skipRepo);
+  run("git", ["config", "user.name", "test"], skipRepo);
+  run("git", ["config", "commit.gpgsign", "false"], skipRepo);
+  // Note: no .gitignore — these dirs are INTENTIONALLY committed to exercise
+  // the SKIP_DIRS filter rather than the .gitignore path.
+  await writeFile(skipRepo, "src/keep/ok.js", "export function ok() {}\n");
+  await writeFile(skipRepo, "dist/bundle/index.js", "router.get('/dist-route', ()=>{});\n");
+  await writeFile(skipRepo, "node_modules/pkg/routes.js", "app.get('/nm', ()=>{});\n");
+  await writeFile(skipRepo, "coverage/lcov/x.js", "server.get('/cov', ()=>{});\n");
+  await writeFile(skipRepo, "build/out.js", "router.post('/b', ()=>{});\n");
+  run("git", ["add", "-A"], skipRepo);
+  run("git", ["commit", "-q", "-m", "initial"], skipRepo);
+  const skipFiles = listGitFiles(skipRepo);
+  const skipSurfaces = await detectSurfaces(skipRepo, skipFiles);
+  const skipSrcModules = skipSurfaces.filter((s) => s.kind === "src-module").map((s) => s.name);
+  assert(skipSrcModules.includes("keep"), "committed real src module is detected");
+  assert(
+    !skipSurfaces.some((s) => s.path.startsWith("dist/")),
+    "dist/ surfaces excluded"
+  );
+  assert(
+    !skipSurfaces.some((s) => s.path.startsWith("node_modules/")),
+    "node_modules/ surfaces excluded"
+  );
+  assert(
+    !skipSurfaces.some((s) => s.path.startsWith("coverage/")),
+    "coverage/ surfaces excluded"
+  );
+  assert(
+    !skipSurfaces.some((s) => s.path.startsWith("build/")),
+    "build/ surfaces excluded"
+  );
+
+  process.stderr.write("\nfileDeclaresRoute ignores commented-out routes\n");
+  const commentRepo = setupDirs("comment-route-repo");
+  run("git", ["init", "-q"], commentRepo);
+  run("git", ["config", "user.email", "test@example.com"], commentRepo);
+  run("git", ["config", "user.name", "test"], commentRepo);
+  run("git", ["config", "commit.gpgsign", "false"], commentRepo);
+  // File that ONLY declares a route inside a comment — should NOT be classified.
+  await writeFile(
+    commentRepo,
+    "src/demo/commented.js",
+    [
+      "// Example of what the route WOULD look like:",
+      "// app.get('/example', (req, res) => res.json({}));",
+      "/* router.post('/nope', () => {}); */",
+      "export function demo() { return 1; }",
+      "",
+    ].join("\n")
+  );
+  // Sanity companion: a real live route in the same repo to confirm detection still fires.
+  await writeFile(
+    commentRepo,
+    "src/real/live.js",
+    [
+      "import express from 'express';",
+      "const router = express.Router();",
+      "router.get('/live', (req, res) => res.json([]));",
+      "export default router;",
+      "",
+    ].join("\n")
+  );
+  run("git", ["add", "-A"], commentRepo);
+  run("git", ["commit", "-q", "-m", "initial"], commentRepo);
+  const commentFiles = listGitFiles(commentRepo);
+  const commentSurfaces = await detectSurfaces(commentRepo, commentFiles);
+  const commentRoutePaths = new Set(
+    commentSurfaces.filter((s) => s.kind === "route-file").map((s) => s.path)
+  );
+  assert(
+    !commentRoutePaths.has("src/demo/commented.js"),
+    "file with ONLY commented routes is NOT classified as a route file"
+  );
+  assert(
+    commentRoutePaths.has("src/real/live.js"),
+    "file with a live route IS still classified"
+  );
 
   if (fs.existsSync(TMP_BASE)) fs.rmSync(TMP_BASE, { recursive: true, force: true });
   if (failed > 0) {

--- a/test/gap-analyzer.test.js
+++ b/test/gap-analyzer.test.js
@@ -1,0 +1,366 @@
+#!/usr/bin/env node
+/**
+ * Gap analyzer assertions — issue #26.
+ *
+ * Uses tmpdir fixtures: builds a miniature "host repo" under `git init` with
+ * src/ modules, route files, SQL schema, and package.json scripts, plus a
+ * tiny vault that covers SOME surfaces but not others. Asserts the gap
+ * report flags the right surfaces and respects .gitignore + JSON shape.
+ */
+import fs from "fs";
+import fsp from "fs/promises";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+import {
+  analyzeGaps,
+  buildVaultHaystack,
+  detectSurfaces,
+  formatMarkdown,
+  listGitFiles,
+  normalizeToken,
+  surfaceIsCovered,
+} from "../lib/gap-analyzer.js";
+import { Vault } from "../lib/vault.js";
+
+const TMP_BASE = path.join(os.tmpdir(), `vault-gap-${process.pid}`);
+
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) process.stderr.write(`  ✓ ${msg}\n`);
+  else {
+    failed++;
+    process.stderr.write(`  ✗ ${msg}\n`);
+  }
+}
+
+function run(cmd, args, cwd) {
+  const res = spawnSync(cmd, args, { cwd, encoding: "utf-8" });
+  if (res.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed in ${cwd}: ${res.stderr || res.stdout}`
+    );
+  }
+  return res.stdout;
+}
+
+async function writeFile(root, rel, content) {
+  const abs = path.join(root, rel);
+  await fsp.mkdir(path.dirname(abs), { recursive: true });
+  await fsp.writeFile(abs, content, "utf-8");
+}
+
+function setupDirs(name) {
+  const root = path.join(TMP_BASE, name);
+  if (fs.existsSync(root)) fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+
+async function buildRepoFixture() {
+  const repo = setupDirs("repo");
+  run("git", ["init", "-q"], repo);
+  run("git", ["config", "user.email", "test@example.com"], repo);
+  run("git", ["config", "user.name", "test"], repo);
+  run("git", ["config", "commit.gpgsign", "false"], repo);
+
+  await writeFile(
+    repo,
+    ".gitignore",
+    ["node_modules/", "dist/", "*.log", ""].join("\n")
+  );
+  await writeFile(
+    repo,
+    "package.json",
+    JSON.stringify(
+      {
+        name: "hostrepo",
+        version: "0.0.1",
+        scripts: {
+          build: "tsc",
+          test: "node --test",
+          "deploy:prod": "./scripts/deploy.sh",
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  // src/ modules
+  await writeFile(repo, "src/auth/login.js", "export function login() {}\n");
+  await writeFile(repo, "src/auth/session.js", "export function session() {}\n");
+  await writeFile(repo, "src/billing/charge.js", "export function charge() {}\n");
+  await writeFile(repo, "src/inventory/sku.js", "export function sku() {}\n");
+
+  // Route file
+  await writeFile(
+    repo,
+    "src/routes/users.js",
+    [
+      "import express from 'express';",
+      "const router = express.Router();",
+      "router.get('/users', (req, res) => res.json([]));",
+      "router.post('/users', (req, res) => res.json({}));",
+      "export default router;",
+    ].join("\n")
+  );
+
+  // Schema file
+  await writeFile(
+    repo,
+    "db/schema.sql",
+    "CREATE TABLE users (id INT PRIMARY KEY, email TEXT);\n"
+  );
+  await writeFile(
+    repo,
+    "db/migrations/001_init.sql",
+    "ALTER TABLE users ADD COLUMN created_at TIMESTAMP;\n"
+  );
+
+  // Files that SHOULD be ignored
+  await writeFile(repo, "node_modules/lodash/index.js", "module.exports = {};\n");
+  await writeFile(repo, "dist/bundle.js", "// bundled\n");
+  await writeFile(repo, "server.log", "ignored log\n");
+
+  // Non-route JS file that should not be flagged as a route
+  await writeFile(
+    repo,
+    "src/utils/format.js",
+    "export function fmt(x) { return String(x); }\n"
+  );
+
+  run("git", ["add", "-A"], repo);
+  run("git", ["commit", "-q", "-m", "initial"], repo);
+
+  return repo;
+}
+
+async function buildVaultFixture({ covers }) {
+  const vaultRoot = setupDirs("vault");
+  const projectDir = path.join(vaultRoot, "proj");
+  fs.mkdirSync(projectDir, { recursive: true });
+
+  // Always create a summary note referencing the vault.
+  await writeFile(
+    projectDir,
+    "VAULT_SUMMARY.md",
+    [
+      "---",
+      "title: Project vault",
+      "tags: [proj, index]",
+      "date: 2026-04-20",
+      "---",
+      "",
+      "# Project vault",
+      "",
+      "Entry point.",
+      "",
+    ].join("\n")
+  );
+
+  if (covers.includes("auth")) {
+    await writeFile(
+      projectDir,
+      "features/auth-login.md",
+      [
+        "---",
+        "title: Auth login",
+        "tags: [auth, feature]",
+        "date: 2026-04-20",
+        "---",
+        "",
+        "# Auth login",
+        "",
+        "Covers the auth module.",
+        "",
+      ].join("\n")
+    );
+  }
+
+  if (covers.includes("schema")) {
+    await writeFile(
+      projectDir,
+      "designs/schema.md",
+      [
+        "---",
+        "title: Database schema",
+        "tags: [schema, db]",
+        "date: 2026-04-20",
+        "---",
+        "",
+        "# Database schema",
+        "",
+        "Describes schema.sql.",
+        "",
+      ].join("\n")
+    );
+  }
+
+  if (covers.includes("build")) {
+    await writeFile(
+      projectDir,
+      "gotchas/build-pipeline.md",
+      [
+        "---",
+        "title: Build pipeline",
+        "tags: [build, ci]",
+        "date: 2026-04-20",
+        "---",
+        "",
+        "# Build pipeline",
+        "",
+        "Notes about the build script.",
+        "",
+      ].join("\n")
+    );
+  }
+
+  const vault = new Vault(vaultRoot);
+  await vault.reindex();
+  return vault;
+}
+
+async function main() {
+  if (fs.existsSync(TMP_BASE)) fs.rmSync(TMP_BASE, { recursive: true, force: true });
+  fs.mkdirSync(TMP_BASE, { recursive: true });
+
+  process.stderr.write("normalizeToken lowercases + strips punctuation\n");
+  assert(normalizeToken("src/Auth/Login.js") === "src auth login js".replace(" js", ""), "strips extension + path separators");
+  assert(normalizeToken("deploy:prod") === "deploy prod", "colon becomes space");
+  assert(normalizeToken("") === "", "empty string safe");
+  assert(normalizeToken(null) === "", "null safe");
+
+  process.stderr.write("\nlistGitFiles honors .gitignore\n");
+  const repo = await buildRepoFixture();
+  const files = listGitFiles(repo);
+  assert(files.includes("package.json"), "tracked root file listed");
+  assert(files.includes("src/auth/login.js"), "tracked src file listed");
+  assert(files.includes("db/schema.sql"), "tracked schema file listed");
+  assert(!files.some((f) => f.startsWith("node_modules/")), "node_modules excluded");
+  assert(!files.some((f) => f.startsWith("dist/")), "dist excluded");
+  assert(!files.some((f) => f.endsWith(".log")), "*.log excluded");
+
+  process.stderr.write("\ndetectSurfaces finds src modules, routes, schemas, scripts\n");
+  const surfaces = await detectSurfaces(repo, files);
+  const byKind = (kind) => surfaces.filter((s) => s.kind === kind);
+  const srcModules = byKind("src-module").map((s) => s.name).sort();
+  assert(
+    JSON.stringify(srcModules) === JSON.stringify(["auth", "billing", "inventory", "routes", "utils"]),
+    `src modules detected: ${srcModules.join(", ")}`
+  );
+  const routeFiles = byKind("route-file").map((s) => s.name);
+  assert(routeFiles.includes("src/routes/users.js"), "express router file detected");
+  assert(!routeFiles.includes("src/utils/format.js"), "non-route js file NOT flagged as route");
+  const schemaFiles = byKind("schema-file").map((s) => s.name).sort();
+  assert(schemaFiles.includes("schema.sql"), "schema.sql detected");
+  assert(schemaFiles.includes("001_init.sql"), "migration .sql detected");
+  const scripts = byKind("script").map((s) => s.name).sort();
+  assert(JSON.stringify(scripts) === JSON.stringify(["build", "deploy:prod", "test"]), "package.json scripts detected");
+
+  process.stderr.write("\nbuildVaultHaystack + surfaceIsCovered substring match\n");
+  const vault = await buildVaultFixture({ covers: ["auth", "schema", "build"] });
+  const haystack = buildVaultHaystack(vault);
+  assert(haystack.includes("auth"), "haystack mentions auth");
+  assert(haystack.includes("schema"), "haystack mentions schema");
+  assert(surfaceIsCovered({ kind: "src-module", name: "auth" }, haystack) === true, "auth src module covered");
+  assert(surfaceIsCovered({ kind: "src-module", name: "inventory" }, haystack) === false, "inventory NOT covered");
+  assert(surfaceIsCovered({ kind: "script", name: "build" }, haystack) === true, "build script covered");
+  assert(surfaceIsCovered({ kind: "script", name: "deploy:prod" }, haystack) === false, "deploy:prod NOT covered");
+  assert(surfaceIsCovered({ kind: "src-module", name: "ab" }, haystack) === false, "too-short token skipped");
+
+  process.stderr.write("\nanalyzeGaps produces sorted gap list\n");
+  const report = await analyzeGaps(vault, repo);
+  assert(report.repo === path.resolve(repo), "report carries resolved repo path");
+  assert(Array.isArray(report.surfaces) && report.surfaces.length > 0, "surfaces array populated");
+  assert(Array.isArray(report.gaps), "gaps is an array");
+  const gapNames = report.gaps.map((g) => `${g.kind}::${g.name}`);
+  assert(gapNames.includes("src-module::inventory"), "inventory module flagged as gap");
+  assert(gapNames.includes("src-module::billing"), "billing module flagged as gap");
+  assert(gapNames.includes("script::deploy:prod"), "deploy:prod script flagged as gap");
+  assert(!gapNames.includes("src-module::auth"), "auth module NOT flagged (covered)");
+  assert(!gapNames.includes("script::build"), "build script NOT flagged (covered)");
+
+  // Sorting: non-null mtime gaps should precede null-mtime gaps (scripts).
+  const firstScriptIdx = report.gaps.findIndex((g) => g.kind === "script");
+  const firstSrcIdx = report.gaps.findIndex((g) => g.kind !== "script" && g.mtime);
+  if (firstScriptIdx >= 0 && firstSrcIdx >= 0) {
+    assert(firstSrcIdx < firstScriptIdx, "mtime-ful surfaces come before null-mtime scripts");
+  }
+
+  process.stderr.write("\nformatMarkdown includes sections and counts\n");
+  const md = formatMarkdown(report);
+  assert(md.startsWith("# Vault Gap Report"), "markdown starts with title");
+  assert(md.includes("**Repo**"), "markdown lists repo");
+  assert(md.includes("**Gaps (no vault mention)**"), "markdown summarizes gap count");
+  assert(md.includes("Source modules"), "markdown has src-module section");
+  assert(md.includes("inventory"), "markdown lists inventory gap");
+
+  process.stderr.write("\nformatMarkdown handles zero-gap case\n");
+  const fullCoverVault = await buildVaultFixture({
+    covers: ["auth", "schema", "build"],
+  });
+  // Rebuild with a vault that mentions every surface.
+  const vaultRoot2 = setupDirs("vault-full");
+  const projectDir2 = path.join(vaultRoot2, "proj");
+  await writeFile(
+    projectDir2,
+    "overview.md",
+    [
+      "---",
+      "title: Coverage",
+      "tags: [auth, billing, inventory, routes, utils, users, schema, migrations, build, test, deploy]",
+      "date: 2026-04-20",
+      "---",
+      "",
+      "# Coverage",
+      "Links: [[auth]] [[billing]] [[inventory]] [[routes]] [[utils]] [[users]] [[schema]] [[deploy prod]] [[001 init]] [[format]]",
+      "",
+    ].join("\n")
+  );
+  const vaultFull = new Vault(vaultRoot2);
+  await vaultFull.reindex();
+  const fullReport = await analyzeGaps(vaultFull, repo);
+  // Not guaranteed to hit zero (some tokens like "users" route file full path
+  // may still miss), so just assert the happy-path empty format doesn't crash:
+  const fullMd = formatMarkdown({
+    ...fullReport,
+    gaps: [],
+  });
+  assert(fullMd.includes("No gaps detected"), "empty-gap report renders cleanly");
+  // Keep the lint clean:
+  void fullCoverVault;
+
+  process.stderr.write("\nJSON shape matches contract\n");
+  const parsed = JSON.parse(JSON.stringify(report));
+  assert(typeof parsed.generatedAt === "string", "generatedAt is a string");
+  assert(Array.isArray(parsed.surfaces), "surfaces array present");
+  for (const g of parsed.gaps) {
+    assert(typeof g.kind === "string" && typeof g.name === "string", `gap has kind+name (${g.kind})`);
+    assert(g.covered === false, `gap.covered always false (${g.name})`);
+  }
+
+  process.stderr.write("\nlistGitFiles on non-repo throws\n");
+  const notRepo = path.join(TMP_BASE, "not-a-repo");
+  fs.mkdirSync(notRepo, { recursive: true });
+  let threw = false;
+  try {
+    listGitFiles(notRepo);
+  } catch {
+    threw = true;
+  }
+  assert(threw, "non-repo path rejected");
+
+  if (fs.existsSync(TMP_BASE)) fs.rmSync(TMP_BASE, { recursive: true, force: true });
+  if (failed > 0) {
+    process.stderr.write(`\n✗ ${failed} assertion(s) failed\n`);
+    process.exit(1);
+  }
+  process.stderr.write("\n✓ All gap-analyzer assertions passed.\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  if (fs.existsSync(TMP_BASE)) fs.rmSync(TMP_BASE, { recursive: true, force: true });
+  process.exit(1);
+});

--- a/vault/claude-code-vault/architecture/web-viewer.md
+++ b/vault/claude-code-vault/architecture/web-viewer.md
@@ -1,0 +1,53 @@
+---
+id: web-viewer
+title: Web viewer architecture
+description: The Express + Vite SPA that renders the vault as a browsable knowledge graph in the browser
+summary: How lib/server.js boots, what HTTP endpoints it exposes, how it shares the indexer with the CLI/MCP surfaces, and how the Vite-built frontend is served.
+type: architecture
+status: current
+lastVerified: 2026-04-20
+tags: [viewer, server, http, express, vite, lib/server.js]
+---
+
+# Web viewer architecture
+
+The web viewer is an optional browsing UI for the vault. It runs as a single Express process that both serves a built Vite SPA and exposes a small JSON API over the same indexer used by the CLI and the MCP server.
+
+## Entry point
+
+`lib/server.js` is the full server. There is no separate router module — all routes are declared inline.
+
+## HTTP surface
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/notes` | List all notes; optional `?tag=<name>` filter |
+| `GET` | `/api/notes/*` | Read a single note by id (supports nested ids like `architecture/web-viewer`) |
+| `GET` | `/api/search` | Keyword search over titles, tags, body |
+| `GET` | `/api/graph` | Return the full wiki-link graph for visualization |
+| `GET` | `/api/tags` | List every unique tag with counts |
+| `POST` | `/api/reindex` | Force a full re-index; returns note count + timestamp |
+| `GET` | `*` | SPA fallback — serves `web/dist/index.html` |
+
+The splat route for `/api/notes/*` is intentional — it accepts nested ids, which matters because note ids are path-shaped (e.g. `architecture/mcp-server`).
+
+## Lifecycle
+
+1. Server reads `VAULT_DIR` from env; falls back to `./vault` if unset.
+2. Instantiates a `Vault` and calls `reindex()` **before** calling `app.listen`, so the first request never hits an empty index.
+3. `chokidar` watches `<vaultDir>/**/*.md` — any add/change/unlink triggers a full reindex.
+4. Listens on `PORT` (default `4001`).
+
+## How it shares state with CLI and MCP
+
+All three surfaces (viewer, CLI, MCP) construct their own `Vault` instance against the same filesystem. They do not share memory — instead they share the on-disk `.vault-cache/` and the markdown files themselves. The viewer's chokidar watcher picks up edits made by the CLI within a few hundred milliseconds.
+
+## Frontend pairing
+
+The SPA lives in `web/` and is built with Vite into `web/dist/`. The server serves those static files after mounting the API routes, so a `/api/*` path always wins over the SPA fallback.
+
+Dev mode uses `concurrently` to run the server under `node --watch` alongside the Vite dev server — see [[claude-code-vault/runbooks/npm-scripts]].
+
+## Why Express and not a framework
+
+The viewer has one job: render what the indexer already built. A framework would introduce build-time ceremony and routing conventions that this tiny surface doesn't need. Raw Express + a handful of routes stays close to the data and is easy to read end-to-end.

--- a/vault/claude-code-vault/gotchas/gotchas.md
+++ b/vault/claude-code-vault/gotchas/gotchas.md
@@ -2,7 +2,7 @@
 id: gotchas
 title: Gotchas
 description: Real failure modes you'll hit when running, installing, or extending claude-code-vault, and the fix for each
-summary: Real failure modes — NODE_MODULE_VERSION, sqlite-vec rowid ambiguity, cache filename bumps, MCP stdout discipline, chokidar reindex behavior, ANTHROPIC_API_KEY hygiene, no --no-verify or --squash. Read before shipping.
+summary: Real failure modes — NODE_MODULE_VERSION, sqlite-vec rowid ambiguity, cache filename bumps, MCP stdout discipline, chokidar reindex behavior, ANTHROPIC_API_KEY hygiene, no --no-verify or --squash, vault gap matcher quirks. Read before shipping.
 type: gotcha
 status: current
 lastVerified: 2026-04-20
@@ -68,3 +68,28 @@ Each gotcha is one H2 section so it can be retrieved on its own. Every section f
 **Cause**: squash-merging collapses the commit trail that this repo's docs point at, and `--no-verify` skips the hooks that catch the breakage before it ships.
 
 **Fix**: merge PRs with `gh pr merge --merge --delete-branch`. Always run pre-commit hooks. If a hook fails, fix the root cause — don't bypass it.
+
+## `vault gap` reports a note as uncovered despite semantic coverage
+
+**Symptom**: A surface like `lib/server.js` lands in `mentioned` or `uncovered` even though a dedicated note exists describing it.
+
+**Cause**: The matcher is deliberately strict — "covered" requires the surface's normalized token (e.g. `lib server`) to appear as a substring of a note's id, title, tag, or wiki-link target. Note bodies are checked separately as the weaker "mentioned" signal. A note titled "Web viewer architecture" with id `web-viewer` semantically covers `lib/server.js` but doesn't satisfy the tokenic match. Strictness is by design: looser matching would false-positive constantly on common words like `server`, `config`, `utils`.
+
+**Fix**: add the surface name as a tag in the note's frontmatter — `tags: [viewer, server, lib/server.js]`. Tags double as accurate metadata and as matcher-visible tokens. See `vault/claude-code-vault/architecture/web-viewer.md` for the pattern.
+
+## `vault gap` only detects modules under `src/`
+
+**Symptom**: Running `vault gap` on a monorepo with `packages/<name>` or `apps/<name>` layouts reports zero source modules.
+
+**Cause**: `detectSurfaces` in `lib/gap-analyzer.js` hardcodes `parts[0] === "src"` when extracting top-level module names. Repos using `packages/`, `apps/`, `lib/` at the root, or a flat layout get no src-module surfaces. Route files and schemas still get detected via content/filename heuristics; only the `src-module` dimension silently collapses.
+
+**Fix**: known limitation — a future config option (`--roots src,packages,apps`) will make this user-tunable. For now, route and schema surfaces still give useful coverage signal on non-standard layouts.
+
+## `vault gap` flags a file as a route because of commented-out code
+
+**Symptom**: A test fixture or example file with commented-out `app.get('/example', ...)` is classified as a `route-file`.
+
+**Cause**: Route detection uses regex (`app.(get|post|...)(`, `router.(get|post|...)(`, framework decorators) against file content. `stripComments` removes `//` and `/* */` comments, but matches inside string literals (e.g. `const doc = "app.get is used for..."` or multi-line template strings) still trigger the regex. Note: the analyzer's own test file `test/gap-analyzer.test.js` is a known self-inflicted case — its fixtures contain `router.get(...)` strings.
+
+**Fix**: accept as-is for now — the heuristic is intentionally loose. If a false-positive becomes painful, either rename the file out of the route-candidate extension set or move the example code into a markdown fence (which isn't scanned).
+

--- a/vault/claude-code-vault/runbooks/npm-scripts.md
+++ b/vault/claude-code-vault/runbooks/npm-scripts.md
@@ -1,0 +1,48 @@
+---
+id: npm-scripts
+title: npm scripts reference
+description: What each package.json script does and when to run it
+summary: Canonical reference for every script in package.json — dev vs start, the setup script, vault:* commands, and how they relate to the CLI, MCP server, and web viewer.
+type: runbook
+status: current
+lastVerified: 2026-04-20
+tags: [runbook, scripts, cli, dev, build, start, setup, vault:index, vault:list, vault:search, vault:export]
+---
+
+# npm scripts reference
+
+All scripts in `package.json` and when to use each.
+
+## Development
+
+| Script | Command | When to use |
+|--------|---------|-------------|
+| `dev` | `concurrently "node --watch lib/server.js" "cd web && npm run dev"` | Active development — runs the API server under `node --watch` and the Vite dev server for the web viewer in parallel |
+| `build` | `cd web && npm run build` | Build the web viewer SPA into `web/dist/` before `start` or release |
+| `start` | `node lib/server.js` | Run the web viewer in production mode (expects `web/dist/` to exist) |
+| `setup` | `npm install && cd web && npm install` | First-time setup — installs root deps **and** web/ deps in one shot |
+
+## MCP server
+
+| Script | Command | When to use |
+|--------|---------|-------------|
+| `mcp` | `node lib/mcp.js` | Run the stdio MCP server — normally invoked by Claude Desktop / Claude Code via their MCP config, not manually |
+
+## CLI
+
+| Script | Command | When to use |
+|--------|---------|-------------|
+| `cli` | `node index.js` | Entry point for the CLI; prefer calling `claude-code-vault` directly once installed |
+| `vault:index` | `node index.js index` | Rebuild the `.vault-cache/` SQLite index — rarely needed; the viewer and MCP server re-index on startup |
+| `vault:list` | `node index.js list` | List every note with frontmatter — useful for debugging ids and tags |
+| `vault:search` | `node index.js search <query>` | Keyword search from the terminal without booting the viewer |
+| `vault:export` | `node index.js export` | Emit the full vault as JSON for external tooling or backups |
+
+## Which one do I actually run?
+
+- **Writing notes day-to-day:** `npm run dev`, then edit markdown, let chokidar reindex.
+- **Checking what's in the vault from the terminal:** `npm run vault:list` or `npm run vault:search "<query>"`.
+- **Shipping the tarball:** `npm run build` then `npm publish` — see [[claude-code-vault/runbooks/publish-release]].
+- **Running under Claude Desktop:** the `mcp` script, wired via the MCP config. Never run it in a terminal expecting output — stdout is reserved for JSON-RPC.
+
+See [[claude-code-vault/architecture/web-viewer]] for how `start` and `dev` wire up, and [[claude-code-vault/architecture/mcp-server]] for the `mcp` path.


### PR DESCRIPTION
## Summary
- Adds `claude-code-vault gap <repo-path>` that walks the host repo (via `git ls-files` so .gitignore is honored), extracts significant surfaces (top-level `src/` subdirs, route-declaring files, `*.sql`/`schema.prisma`/migration dirs, `package.json` scripts), cross-references them against vault note ids/titles/tags/wiki-link targets, and reports gaps sorted by `git log` recency of last touch.
- Both markdown (default) and JSON (`--json`) output are supported so the command can feed into scripts or a future weekly GH Actions workflow.

## Changes
- `lib/gap-analyzer.js` (new): `listGitFiles`, `detectSurfaces`, `buildVaultHaystack`, `surfaceIsCovered`, `analyzeGaps`, `formatMarkdown`. Conservative substring matching against a normalized haystack (lowercased, punctuation stripped, tokens `>=3` chars).
- `index.js`: new `gap` command that reindexes the vault, runs `analyzeGaps`, and prints markdown or JSON.
- `test/gap-analyzer.test.js` (new): tmpdir git-fixture host repo + mini vault; asserts gitignore compliance, src-module / route / schema / script detection, coverage matching, sort order, JSON shape, and error handling for non-repo paths.
- `package-lock.json`: incidental version-bump sync (0.1.0 → 0.2.0) from `npm install`.

## Acceptance criteria (from #26)
- [x] CLI scans host repo + vault, produces a markdown report
- [x] Respects `.gitignore` (uses `git ls-files`)
- [x] Surfaces sorted by recent activity (`git log -1 --format=%cI`)
- [x] JSON output for scripting

## Verification
- [x] `npm install --no-audit --no-fund`
- [x] `node --test test/gap-analyzer.test.js` — all assertions pass
- [x] `node index.js gap .` — meta-smoke against claude-vault itself
- [x] `node lib/mcp.js` still boots

Closes #26