### PR TITLE
feat: tighten retrieval eval gate with warn/fail tiers (closes #28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: node index.js lint --format github
 
       - name: Retrieval eval (recall@5 vs baseline)
-        run: node test/retrieval/eval.js --gate 5
+        run: node test/retrieval/eval.js --gate 2 --warn-gate 0.5
 
       - name: Status-aware retrieval assertions
         run: node test/retrieval/status_filter.test.js

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "vault:index": "node index.js index",
     "vault:search": "node index.js search",
     "vault:export": "node index.js export",
-    "vault:list": "node index.js list"
+    "vault:list": "node index.js list",
+    "eval": "node test/retrieval/eval.js",
+    "eval:bless": "node test/retrieval/eval.js --update-baseline"
   },
   "bin": {
     "claude-code-vault": "index.js"

--- a/test/retrieval/eval.js
+++ b/test/retrieval/eval.js
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
 /**
- * Retrieval eval harness — issue #15.
+ * Retrieval eval harness — issue #15 + #28.
  *
  * Runs every gold query against keyword / semantic / chunk search and
  * reports recall@5 + MRR@5. Compares against test/retrieval/baseline.json
- * if present, exits non-zero when a tool's recall@5 drops by more than
- * the gate (default 5pp).
+ * if present and applies a two-tier gate:
+ *   - drop > --gate pp (default 2pp) on any tool → fail (exit 1)
+ *   - drop between --warn-gate (default 0.5pp) and --gate pp → warn on
+ *     stderr as a GitHub Actions workflow annotation, exit 0
  *
  * Usage:
- *   node test/retrieval/eval.js                  # eval + diff vs baseline
- *   node test/retrieval/eval.js --update-baseline
- *   node test/retrieval/eval.js --gate 10        # tolerate up to 10pp drop
- *   node test/retrieval/eval.js --json           # machine-readable output
- *   node test/retrieval/eval.js --vault ./vault  # override vault dir
+ *   node test/retrieval/eval.js                     # eval + diff vs baseline
+ *   node test/retrieval/eval.js --update-baseline   # rewrite baseline.json
+ *   node test/retrieval/eval.js --gate 2            # fail threshold in pp
+ *   node test/retrieval/eval.js --warn-gate 0.5     # warn threshold in pp
+ *   node test/retrieval/eval.js --json              # machine-readable output
+ *   node test/retrieval/eval.js --vault ./vault     # override vault dir
  */
 import fs from "fs";
 import path from "path";
@@ -32,7 +35,8 @@ const K = 5;
 function parseArgs(argv) {
   const args = {
     updateBaseline: false,
-    gate: 5,
+    gate: 2,
+    warnGate: 0.5,
     json: false,
     hyde: false,
     vault: path.resolve(__dirname, "..", "..", "vault"),
@@ -45,18 +49,33 @@ function parseArgs(argv) {
     else if (a === "--json") args.json = true;
     else if (a === "--hyde") args.hyde = true;
     else if (a === "--gate") args.gate = Number(argv[++i]);
+    else if (a === "--warn-gate") args.warnGate = Number(argv[++i]);
     else if (a === "--vault") args.vault = path.resolve(argv[++i]);
     else if (a === "--gold") args.gold = path.resolve(argv[++i]);
     else if (a === "--baseline") args.baseline = path.resolve(argv[++i]);
     else if (a === "--help" || a === "-h") {
       console.log(
-        "Usage: node test/retrieval/eval.js [--update-baseline] [--gate N] [--json] [--hyde] [--vault DIR] [--gold FILE] [--baseline FILE]",
+        "Usage: node test/retrieval/eval.js [--update-baseline] [--gate N] [--warn-gate N] [--json] [--hyde] [--vault DIR] [--gold FILE] [--baseline FILE]",
       );
       process.exit(0);
     } else {
       console.error(`Unknown arg: ${a}`);
       process.exit(2);
     }
+  }
+  if (!Number.isFinite(args.gate) || args.gate < 0) {
+    console.error(`--gate must be a non-negative number (got ${args.gate})`);
+    process.exit(2);
+  }
+  if (!Number.isFinite(args.warnGate) || args.warnGate < 0) {
+    console.error(`--warn-gate must be a non-negative number (got ${args.warnGate})`);
+    process.exit(2);
+  }
+  if (args.warnGate > args.gate) {
+    console.error(
+      `--warn-gate (${args.warnGate}pp) must be <= --gate (${args.gate}pp)`,
+    );
+    process.exit(2);
   }
   return args;
 }
@@ -261,19 +280,23 @@ function fmtDelta(n, isPct) {
   return isPct ? `${sign}${(n * 100).toFixed(1)}pp` : `${sign}${n.toFixed(3)}`;
 }
 
-function checkRegression(result, baseline, gatePp) {
-  if (!baseline) return { ok: true, regressions: [] };
-  const regressions = [];
+function checkRegression(result, baseline, failGatePp, warnGatePp) {
+  if (!baseline) return { ok: true, failures: [], warnings: [] };
+  const failures = [];
+  const warnings = [];
   for (const tool of Object.keys(result.summary)) {
     const cur = result.summary[tool].overall.recallAt5;
     const base = baseline.summary?.[tool]?.overall?.recallAt5;
     if (base === undefined) continue;
     const dropPp = (base - cur) * 100;
-    if (dropPp > gatePp) {
-      regressions.push({ tool, basePct: base * 100, curPct: cur * 100, dropPp });
+    const entry = { tool, basePct: base * 100, curPct: cur * 100, dropPp };
+    if (dropPp > failGatePp) {
+      failures.push(entry);
+    } else if (dropPp > warnGatePp) {
+      warnings.push(entry);
     }
   }
-  return { ok: regressions.length === 0, regressions };
+  return { ok: failures.length === 0, failures, warnings };
 }
 
 async function main() {
@@ -302,19 +325,46 @@ async function main() {
   }
 
   if (!opts.updateBaseline) {
-    const { ok, regressions } = checkRegression(result, baseline, opts.gate);
-    if (!ok) {
+    reportRegressions(result, baseline, opts);
+  }
+}
+
+function reportRegressions(result, baseline, opts) {
+  const { ok, failures, warnings } = checkRegression(
+    result,
+    baseline,
+    opts.gate,
+    opts.warnGate,
+  );
+
+  const baselineRel =
+    path.relative(process.cwd(), opts.baseline) || opts.baseline;
+
+  for (const w of warnings) {
+    const msg = `${w.tool}: recall@5 ${w.basePct.toFixed(1)}% -> ${w.curPct.toFixed(1)}% (-${w.dropPp.toFixed(1)}pp, within warn zone ${opts.warnGate}-${opts.gate}pp)`;
+    // GitHub Actions workflow command on stderr — shows up as a PR annotation.
+    process.stderr.write(`::warning file=${baselineRel}::${msg}\n`);
+  }
+
+  if (!ok) {
+    console.error(
+      `\n✗ Regression: ${failures.length} tool(s) dropped recall@5 by more than ${opts.gate}pp`,
+    );
+    for (const r of failures) {
       console.error(
-        `\n✗ Regression: ${regressions.length} tool(s) dropped recall@5 by more than ${opts.gate}pp`,
+        `  ${r.tool}: ${r.basePct.toFixed(1)}% → ${r.curPct.toFixed(1)}% (-${r.dropPp.toFixed(1)}pp)`,
       );
-      for (const r of regressions) {
-        console.error(
-          `  ${r.tool}: ${r.basePct.toFixed(1)}% → ${r.curPct.toFixed(1)}% (-${r.dropPp.toFixed(1)}pp)`,
-        );
-      }
-      process.exit(1);
     }
-    if (baseline) console.log("✓ No retrieval regression.");
+    process.exit(1);
+  }
+
+  if (!baseline) return;
+  if (warnings.length > 0) {
+    console.log(
+      `⚠ ${warnings.length} tool(s) in warn zone (${opts.warnGate}-${opts.gate}pp drop). See stderr annotations.`,
+    );
+  } else {
+    console.log("✓ No retrieval regression.");
   }
 }
 

--- a/test/retrieval/eval.js
+++ b/test/retrieval/eval.js
@@ -71,9 +71,9 @@ function parseArgs(argv) {
     console.error(`--warn-gate must be a non-negative number (got ${args.warnGate})`);
     process.exit(2);
   }
-  if (args.warnGate > args.gate) {
+  if (args.warnGate >= args.gate) {
     console.error(
-      `--warn-gate (${args.warnGate}pp) must be <= --gate (${args.gate}pp)`,
+      `error: --warn-gate (${args.warnGate}) must be less than --gate (${args.gate})`,
     );
     process.exit(2);
   }

--- a/vault/claude-code-vault/runbooks/retrieval-eval.md
+++ b/vault/claude-code-vault/runbooks/retrieval-eval.md
@@ -1,0 +1,75 @@
+---
+id: retrieval-eval
+title: Retrieval eval + regression gate
+description: How to run the retrieval eval harness, interpret results, and bless a new baseline
+summary: The retrieval eval harness runs every gold query against keyword, semantic, and chunk search and compares recall@5 against test/retrieval/baseline.json. CI fails PRs on >2pp drops and annotates PRs on 0.5-2pp drops. Bless a new baseline with `npm run eval:bless` only when the improvement is deliberate.
+type: runbook
+status: current
+lastVerified: 2026-04-20
+tags: [runbook, retrieval, eval, ci, baseline, recall, mrr, gold, regression, gate]
+---
+
+# Retrieval eval + regression gate
+
+The retrieval eval harness (`test/retrieval/eval.js`) measures recall@5 and MRR@5 across the three retrieval surfaces (keyword, semantic, chunks) over a gold query set (`test/retrieval/gold.json`). CI runs it on every PR and gates merges on regression.
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `npm run eval` | Run the eval and diff against `test/retrieval/baseline.json`. Non-zero exit on >2pp drop on any tool. |
+| `npm run eval -- --gate 1` | Tighten the fail threshold to 1pp for this run. |
+| `npm run eval -- --warn-gate 0.25` | Tighten the warn threshold to 0.25pp for this run. |
+| `npm run eval -- --hyde` | Run with HyDE query expansion (requires `ANTHROPIC_API_KEY`). |
+| `npm run eval -- --json` | Machine-readable output on stdout (human report suppressed). |
+| `npm run eval:bless` | Overwrite `test/retrieval/baseline.json` with the current metrics. |
+
+## Gate tiers
+
+The gate has two tiers, both computed per tool on recall@5:
+
+1. **Fail** (`--gate`, default `2pp`). Any tool whose recall@5 drops by more than this exits 1. CI blocks the PR.
+2. **Warn** (`--warn-gate`, default `0.5pp`). Drops between the warn and fail thresholds are surfaced as `::warning file=test/retrieval/baseline.json::...` on stderr. GitHub Actions renders those as PR annotations. Exit stays 0.
+
+Drops at or below the warn threshold are silent (noise floor for a 14-query gold set).
+
+Improvements are printed in the human report (`Δrecall +X.Xpp`) but never auto-update the baseline — you must bless deliberately.
+
+## Runbook: when the eval fails on your PR
+
+1. Read the CI log for the eval step. It lists each failing tool with `base% -> cur% (-Xpp)`.
+2. Run locally: `npm run eval -- --gate 2 --warn-gate 0.5` to reproduce.
+3. Classify the drop:
+   - **Unintended regression.** Your change broke something. Fix the code, not the baseline.
+   - **Intentional trade-off** (e.g. a better chunking strategy that costs 3pp on keyword-only queries but wins 8pp on semantic-only). Land the improvement, then bless.
+   - **Gold set is wrong.** The query expected the old behavior. Edit `test/retrieval/gold.json`, re-bless.
+4. If blessing is appropriate, run `npm run eval:bless` and commit the updated `baseline.json` in the same PR as the change that caused the shift. Call it out in the PR description — blessing a baseline without explaining why is the main way retrieval decay sneaks in.
+
+## Runbook: when the eval warns on your PR
+
+A warn-tier drop (0.5-2pp) is a yellow flag, not a blocker. Read the annotation, decide whether to investigate or ignore. The baseline is unchanged — if a subsequent PR pushes the same tool another 1pp, it becomes a fail.
+
+## Why these thresholds
+
+Default `--gate 2` tolerates ~1 query flip on the 14-query gold set (1/14 = 7pp on a per-tool basis, but per-tool averages smooth this). A drop >2pp means at least one real regression, not sampling noise.
+
+Default `--warn-gate 0.5` catches partial-rank drops (e.g. a query moving from rank 2 to rank 5 on chunks) that don't flip recall@5 but do move MRR@5. Over time, multiple silent warns compound.
+
+Tune `--gate` down (1pp or lower) once the gold set grows past ~50 queries — the noise floor drops.
+
+## CI wiring
+
+`.github/workflows/ci.yml` runs:
+
+```yaml
+- name: Retrieval eval (recall@5 vs baseline)
+  run: node test/retrieval/eval.js --gate 2 --warn-gate 0.5
+```
+
+The step runs after the vault lint and before the other retrieval assertions. The web viewer build runs in parallel; the eval does not depend on it.
+
+## Related
+
+- [[claude-code-vault/architecture/retrieval]] — how keyword / semantic / chunk search are layered.
+- [[claude-code-vault/runbooks/npm-scripts]] — every script in `package.json`.
+- Issue #15 (eval harness), #28 (this gate), #25 (query-miss log for discovering gold-set gaps).

--- a/vault/claude-code-vault/runbooks/retrieval-eval.md
+++ b/vault/claude-code-vault/runbooks/retrieval-eval.md
@@ -35,17 +35,33 @@ Drops at or below the warn threshold are silent (noise floor for a 14-query gold
 
 Improvements are printed in the human report (`Δrecall +X.Xpp`) but never auto-update the baseline — you must bless deliberately.
 
-## Runbook: when the eval fails on your PR
+## Steps
 
-1. Read the CI log for the eval step. It lists each failing tool with `base% -> cur% (-Xpp)`.
-2. Run locally: `npm run eval -- --gate 2 --warn-gate 0.5` to reproduce.
-3. Classify the drop:
-   - **Unintended regression.** Your change broke something. Fix the code, not the baseline.
-   - **Intentional trade-off** (e.g. a better chunking strategy that costs 3pp on keyword-only queries but wins 8pp on semantic-only). Land the improvement, then bless.
-   - **Gold set is wrong.** The query expected the old behavior. Edit `test/retrieval/gold.json`, re-bless.
-4. If blessing is appropriate, run `npm run eval:bless` and commit the updated `baseline.json` in the same PR as the change that caused the shift. Call it out in the PR description — blessing a baseline without explaining why is the main way retrieval decay sneaks in.
+Follow these when the eval fails on your PR.
 
-## Runbook: when the eval warns on your PR
+### 1. Read the CI log
+
+The eval step lists each failing tool with `base% -> cur% (-Xpp)`. Note which tool(s) dropped and by how much.
+
+### 2. Reproduce locally
+
+Run `npm run eval -- --gate 2 --warn-gate 0.5`. Same thresholds as CI, same output.
+
+### 3. Classify the drop
+
+- **Unintended regression.** Your change broke something. Fix the code, not the baseline.
+- **Intentional trade-off** (e.g. a better chunking strategy that costs 3pp on keyword-only queries but wins 8pp on semantic-only). Land the improvement, then bless.
+- **Gold set is wrong.** The query expected the old behavior. Edit `test/retrieval/gold.json`, re-bless.
+
+### 4. Bless a new baseline (only if appropriate)
+
+If the shift is intentional, run `npm run eval:bless` and commit the updated `baseline.json` in the same PR as the change that caused the shift. Call it out in the PR description — blessing a baseline without explaining why is the main way retrieval decay sneaks in.
+
+### Verify
+
+Rerun `npm run eval` — it should now pass with `✓ No retrieval regression.` on stdout and exit 0. If CI was the trigger, push the commit and confirm the workflow goes green.
+
+### When the eval warns (not fails)
 
 A warn-tier drop (0.5-2pp) is a yellow flag, not a blocker. Read the annotation, decide whether to investigate or ignore. The baseline is unchanged — if a subsequent PR pushes the same tool another 1pp, it becomes a fail.
 
@@ -70,6 +86,6 @@ The step runs after the vault lint and before the other retrieval assertions. Th
 
 ## Related
 
-- [[claude-code-vault/architecture/retrieval]] — how keyword / semantic / chunk search are layered.
+- [[claude-code-vault/architecture/embeddings-pipeline]] — how keyword / semantic / chunk search are layered.
 - [[claude-code-vault/runbooks/npm-scripts]] — every script in `package.json`.
 - Issue #15 (eval harness), #28 (this gate), #25 (query-miss log for discovering gold-set gaps).


### PR DESCRIPTION
## Summary
- Two-tier retrieval eval gate: fail on recall@5 drops > 2pp, warn on drops 0.5-2pp (exit 0, `::warning` PR annotation on stderr).
- Defaults tightened from 5pp to 2pp; warn zone is new.
- `npm run eval` and `npm run eval:bless` so blessing a baseline is a named command, not a recalled flag.

## Changes
- `test/retrieval/eval.js`: `checkRegression` now returns `{ failures, warnings }` buckets. New `--warn-gate` flag (default 0.5pp), `--gate` default dropped from 5 to 2. Arg parser rejects non-numeric / negative gates and `warn-gate > gate`. Regression reporting extracted to `reportRegressions` helper.
- `package.json`: add `eval` and `eval:bless` scripts.
- `.github/workflows/ci.yml`: eval step now runs with `--gate 2 --warn-gate 0.5`.
- `vault/claude-code-vault/runbooks/retrieval-eval.md`: new runbook covering the two-tier policy, when to bless, and threshold rationale.

## Verification
- [x] `npm install --no-audit --no-fund` clean
- [x] `node test/retrieval/eval.js --gate 2` passes on current baseline
- [x] Baseline hand-inflated +3pp on semantic -> exits 1 with failure report
- [x] Baseline hand-inflated +1pp on semantic -> exit 0, `::warning file=test/retrieval/baseline.json::...` on stderr
- [x] `npm run eval:bless` writes baseline
- [x] Arg validation: `--warn-gate 3 --gate 2` and `--gate foo` both exit 2 with clear messages
- [x] `node --check` clean on `lib/mcp.js`, `test/retrieval/eval.js`, `index.js`

Closes #28