### PR TITLE
feat: enforce char budgets on search tools (closes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Vault location defaults to `./vault`; override with `VAULT_DIR` in `.mcp.json` i
 
 ### Response envelope + char budget
 
-The four search/list tools — `vault_search`, `vault_list`, `vault_semantic_search`, `vault_search_chunks` — return a `{ results, truncated }` envelope. Each accepts an optional `maxChars` parameter (default **8000** ≈ 2000 tokens); lower-ranked results are dropped from the bottom to fit. `truncated: true` means at least one result was dropped. The top-ranked item is always returned even if it alone exceeds the budget, so a non-empty search never yields an empty response. The `*_with_context` tools use the same `maxChars`/`truncated` contract for neighbor snippets.
+The four search/list tools — `vault_search`, `vault_list`, `vault_semantic_search`, `vault_search_chunks` — return a `{ results, truncated }` envelope. Each accepts an optional `maxChars` parameter (default **8000** ≈ 2000 tokens); lower-ranked results are dropped from the bottom to fit. `truncated: true` means at least one result was dropped. The top-ranked item is always returned even if it alone exceeds the budget, so a non-empty search never yields an empty response. The `*_with_context` tools share the `maxChars` budget and `truncated` flag; their top-level envelope shape differs (domain-specific keys like `chunks`, `neighbors`, `note`).
 
 ### Semantic search + chunk retrieval
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Idempotent: re-running skips existing files. After it finishes, restart Claude C
 
 Vault location defaults to `./vault`; override with `VAULT_DIR` in `.mcp.json` if needed.
 
+### Response envelope + char budget
+
+The four search/list tools — `vault_search`, `vault_list`, `vault_semantic_search`, `vault_search_chunks` — return a `{ results, truncated }` envelope. Each accepts an optional `maxChars` parameter (default **8000** ≈ 2000 tokens); lower-ranked results are dropped from the bottom to fit. `truncated: true` means at least one result was dropped. The top-ranked item is always returned even if it alone exceeds the budget, so a non-empty search never yields an empty response. The `*_with_context` tools use the same `maxChars`/`truncated` contract for neighbor snippets.
+
 ### Semantic search + chunk retrieval
 
 Embeddings run locally via `@huggingface/transformers` + `sqlite-vec` — no API key, no cloud. Notes are chunked on markdown heading boundaries (a chunk = text under one heading, bounded to 100–1500 chars with paragraph-level splitting for oversized sections). Each chunk carries a heading breadcrumb (`# Title > ## Section > ### Subsection`) and any wiki-links it contains. First startup downloads ~22MB of ONNX model weights to `.vault-cache/`; subsequent runs only re-embed notes whose `lastModified` changed.

--- a/lib/budgets.js
+++ b/lib/budgets.js
@@ -1,0 +1,63 @@
+/**
+ * Character-budget helpers for MCP search tools (issue #30).
+ *
+ * `applyCharBudget(items, maxChars)` trims a pre-ranked result list so the
+ * JSON-serialized total does not exceed `maxChars`. Drops from the bottom
+ * (results are assumed ranked high-to-low). Honors an at-least-one-result
+ * contract: if the top item alone exceeds the budget, it is still returned
+ * (with `truncated: true`) so the caller never gets an empty response for a
+ * non-empty search.
+ *
+ * Returns an envelope `{ results, truncated }` that the MCP layer serializes
+ * as the tool response. The envelope is always returned — even when the
+ * budget is not hit — so downstream agents can rely on a stable shape.
+ */
+export const DEFAULT_MAX_CHARS = 8000;
+
+/**
+ * Measure an item's contribution to the JSON budget. We use
+ * `JSON.stringify(item).length` so the accounting matches the bytes the
+ * MCP layer will eventually emit.
+ */
+function itemChars(item) {
+  return JSON.stringify(item).length;
+}
+
+/**
+ * Trim `items` to fit within `maxChars` of serialized JSON, dropping from
+ * the bottom. Always returns at least the top item when `items` is
+ * non-empty, even if that single item already exceeds the budget.
+ *
+ * @param {Array<object>} items  pre-ranked list of results
+ * @param {number} maxChars      positive integer char budget
+ * @returns {{ results: Array<object>, truncated: boolean }}
+ */
+export function applyCharBudget(items, maxChars) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return { results: [], truncated: false };
+  }
+
+  const budget = Number.isFinite(maxChars) && maxChars > 0 ? maxChars : DEFAULT_MAX_CHARS;
+  const results = [];
+  let used = 0;
+  let truncated = false;
+
+  for (let i = 0; i < items.length; i++) {
+    const size = itemChars(items[i]);
+    if (results.length === 0) {
+      // At-least-one-result contract: keep top item even if it busts budget.
+      results.push(items[i]);
+      used += size;
+      if (used > budget) truncated = true;
+      continue;
+    }
+    if (used + size > budget) {
+      truncated = true;
+      break;
+    }
+    results.push(items[i]);
+    used += size;
+  }
+
+  return { results, truncated };
+}

--- a/lib/budgets.js
+++ b/lib/budgets.js
@@ -11,8 +11,21 @@
  * Returns an envelope `{ results, truncated }` that the MCP layer serializes
  * as the tool response. The envelope is always returned — even when the
  * budget is not hit — so downstream agents can rely on a stable shape.
+ *
+ * Accounting includes:
+ *  - `WRAPPER_OVERHEAD` — a fixed allowance for the envelope bytes
+ *    (`{"results":[],"truncated":false}` ≈ 32 chars; rounded to 40 to leave
+ *    slack for the flipped `truncated: true` path and any future wrapper
+ *    keys). Subtracted from the caller's `maxChars` up-front.
+ *  - comma separators between array elements — 1 byte per item except the
+ *    first. Without this the budget can overshoot by N-1 bytes for N items.
+ *
+ * At tight budgets (a few hundred chars) this tightening matters; at the
+ * 8000-char default it is negligible. Documented so callers passing very
+ * small `maxChars` values understand the effective-budget math.
  */
 export const DEFAULT_MAX_CHARS = 8000;
+export const WRAPPER_OVERHEAD = 40;
 
 /**
  * Measure an item's contribution to the JSON budget. We use
@@ -26,7 +39,9 @@ function itemChars(item) {
 /**
  * Trim `items` to fit within `maxChars` of serialized JSON, dropping from
  * the bottom. Always returns at least the top item when `items` is
- * non-empty, even if that single item already exceeds the budget.
+ * non-empty, even if that single item already exceeds the effective budget
+ * (effective = `maxChars` minus wrapper overhead). Comma separators
+ * between items are included in the running total.
  *
  * @param {Array<object>} items  pre-ranked list of results
  * @param {number} maxChars      positive integer char budget
@@ -37,26 +52,30 @@ export function applyCharBudget(items, maxChars) {
     return { results: [], truncated: false };
   }
 
-  const budget = Number.isFinite(maxChars) && maxChars > 0 ? maxChars : DEFAULT_MAX_CHARS;
+  const rawBudget = Number.isFinite(maxChars) && maxChars > 0 ? maxChars : DEFAULT_MAX_CHARS;
+  // Subtract fixed wrapper overhead so the final serialized envelope fits.
+  const budget = Math.max(0, rawBudget - WRAPPER_OVERHEAD);
   const results = [];
   let used = 0;
   let truncated = false;
 
-  for (let i = 0; i < items.length; i++) {
-    const size = itemChars(items[i]);
+  for (const item of items) {
+    const size = itemChars(item);
+    // Comma separator between items: 1 byte per item except the first.
+    const sep = results.length === 0 ? 0 : 1;
     if (results.length === 0) {
       // At-least-one-result contract: keep top item even if it busts budget.
-      results.push(items[i]);
+      results.push(item);
       used += size;
       if (used > budget) truncated = true;
       continue;
     }
-    if (used + size > budget) {
+    if (used + sep + size > budget) {
       truncated = true;
       break;
     }
-    results.push(items[i]);
-    used += size;
+    results.push(item);
+    used += sep + size;
   }
 
   return { results, truncated };

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -5,11 +5,15 @@ import { z } from "zod";
 import chokidar from "chokidar";
 import fsSync from "fs";
 import path from "path";
+import { createRequire } from "node:module";
 import { Vault } from "./vault.js";
 import { lintVault } from "./linter.js";
 import { createNote, writeNote, editSection } from "./vault-write.js";
 import { appendEntry, isLoggingEnabled } from "./query-log.js";
 import { applyCharBudget, DEFAULT_MAX_CHARS } from "./budgets.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json");
 
 const queryLogEnabled = isLoggingEnabled();
 async function logQuery(tool, query, results, options) {
@@ -70,7 +74,7 @@ const watcher = chokidar
   .watch(vaultDir, { ignoreInitial: true, ignored: /(^|[\/\\])\../ })
   .on("all", scheduleReindex);
 
-const server = new McpServer({ name: "claude-code-vault", version: "0.1.0" });
+const server = new McpServer({ name: "claude-code-vault", version: pkg.version });
 
 const safe = (handler) => async (args) => {
   try {
@@ -113,11 +117,12 @@ server.registerTool(
         lastVerified,
       }));
     const envelope = applyCharBudget(ranked, maxChars);
-    await logQuery("vault_search", query, envelope.results, {
+    await logQuery("vault_search", query, ranked, {
       limit,
       includeDeprecated,
       staleWeight,
       maxChars,
+      truncated: envelope.truncated,
     });
     return {
       content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
@@ -268,7 +273,7 @@ if (embeddingsDb) {
         staleWeight,
       });
       const envelope = applyCharBudget(results, maxChars);
-      await logQuery("vault_semantic_search", query, envelope.results, {
+      await logQuery("vault_semantic_search", query, results, {
         limit,
         folder,
         tag,
@@ -278,6 +283,7 @@ if (embeddingsDb) {
         includeDeprecated,
         staleWeight,
         maxChars,
+        truncated: envelope.truncated,
       });
       return {
         content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
@@ -322,7 +328,7 @@ if (embeddingsDb) {
         staleWeight,
       });
       const envelope = applyCharBudget(results, maxChars);
-      await logQuery("vault_search_chunks", query, envelope.results, {
+      await logQuery("vault_search_chunks", query, results, {
         limit,
         folder,
         tag,
@@ -332,6 +338,7 @@ if (embeddingsDb) {
         includeDeprecated,
         staleWeight,
         maxChars,
+        truncated: envelope.truncated,
       });
       return {
         content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -9,6 +9,7 @@ import { Vault } from "./vault.js";
 import { lintVault } from "./linter.js";
 import { createNote, writeNote, editSection } from "./vault-write.js";
 import { appendEntry, isLoggingEnabled } from "./query-log.js";
+import { applyCharBudget, DEFAULT_MAX_CHARS } from "./budgets.js";
 
 const queryLogEnabled = isLoggingEnabled();
 async function logQuery(tool, query, results, options) {
@@ -87,16 +88,17 @@ server.registerTool(
   "vault_search",
   {
     description:
-      "Search vault notes by keyword. Matches against note title, tags, and id — NOT body content. Returns notes ranked by relevance. Status-aware: notes with `status: deprecated` are excluded by default; `status: stale` is downranked. Pass `includeDeprecated: true` to include deprecated notes; pass `staleWeight` (0..1, default 0.7) to tune the stale penalty.",
+      "Search vault notes by keyword. Matches against note title, tags, and id — NOT body content. Returns notes ranked by relevance. Status-aware: notes with `status: deprecated` are excluded by default; `status: stale` is downranked. Pass `includeDeprecated: true` to include deprecated notes; pass `staleWeight` (0..1, default 0.7) to tune the stale penalty. Response shape: `{ results, truncated }` — results are the ranked note summaries; `truncated: true` indicates lower-ranked results were dropped to fit the `maxChars` budget (default 8000 ≈ 2000 tokens). The top-ranked result is always returned even if it alone exceeds the budget.",
     inputSchema: {
       query: z.string(),
       limit: z.number().int().positive().optional(),
       includeDeprecated: z.boolean().optional(),
       staleWeight: z.number().min(0).max(1).optional(),
+      maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
     },
   },
-  safe(async ({ query, limit, includeDeprecated, staleWeight }) => {
-    const results = vault
+  safe(async ({ query, limit, includeDeprecated, staleWeight, maxChars }) => {
+    const ranked = vault
       .search(query, { includeDeprecated, staleWeight })
       .slice(0, limit ?? 10)
       .map(({ id, title, tags, relevance, wordCount, status, type, summary, lastVerified }) => ({
@@ -110,9 +112,15 @@ server.registerTool(
         summary,
         lastVerified,
       }));
-    await logQuery("vault_search", query, results, { limit, includeDeprecated, staleWeight });
+    const envelope = applyCharBudget(ranked, maxChars);
+    await logQuery("vault_search", query, envelope.results, {
+      limit,
+      includeDeprecated,
+      staleWeight,
+      maxChars,
+    });
     return {
-      content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+      content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
     };
   })
 );
@@ -155,10 +163,13 @@ server.registerTool(
   "vault_list",
   {
     description:
-      "List all vault notes, optionally filtered by a tag. Returns id, title, tags, and word count for each.",
-    inputSchema: { tag: z.string().optional() },
+      "List all vault notes, optionally filtered by a tag. Returns id, title, tags, and word count for each. Response shape: `{ results, truncated }`. Results are trimmed from the bottom to fit `maxChars` (default 8000 ≈ 2000 tokens); `truncated: true` means more notes exist but were dropped. Use a larger `maxChars` to paginate by byte budget.",
+    inputSchema: {
+      tag: z.string().optional(),
+      maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
+    },
   },
-  safe(async ({ tag }) => {
+  safe(async ({ tag, maxChars }) => {
     const notes = vault.list(tag).map(({ id, title, tags, wordCount, status, type, summary, lastVerified }) => ({
       id,
       title,
@@ -169,8 +180,9 @@ server.registerTool(
       summary,
       lastVerified,
     }));
+    const envelope = applyCharBudget(notes, maxChars);
     return {
-      content: [{ type: "text", text: JSON.stringify(notes, null, 2) }],
+      content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
     };
   })
 );
@@ -223,7 +235,7 @@ if (embeddingsDb) {
     "vault_semantic_search",
     {
       description:
-        "Search vault notes by meaning, not exact keywords. Returns notes ranked by cosine similarity of their best-matching chunk to the query, along with the heading path of that best chunk. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: deprecated notes are excluded and stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use when looking for notes *about* a concept (e.g. 'notes about authentication'). Pair with vault_read when you need the full note, or vault_search_chunks when you only need the most relevant paragraphs.",
+        "Search vault notes by meaning, not exact keywords. Returns notes ranked by cosine similarity of their best-matching chunk to the query, along with the heading path of that best chunk. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: deprecated notes are excluded and stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use when looking for notes *about* a concept (e.g. 'notes about authentication'). Pair with vault_read when you need the full note, or vault_search_chunks when you only need the most relevant paragraphs. Response shape: `{ results, truncated }` — lower-ranked matches are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top match is always returned.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
@@ -234,9 +246,10 @@ if (embeddingsDb) {
         hyde: z.boolean().optional(),
         includeDeprecated: z.boolean().optional(),
         staleWeight: z.number().min(0).max(1).optional(),
+        maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
       },
     },
-    safe(async ({ query, limit, folder, tag, after, before, hyde, includeDeprecated, staleWeight }) => {
+    safe(async ({ query, limit, folder, tag, after, before, hyde, includeDeprecated, staleWeight, maxChars }) => {
       await embeddingsReady;
       if (!embeddingsDb) {
         return {
@@ -254,7 +267,8 @@ if (embeddingsDb) {
         includeDeprecated,
         staleWeight,
       });
-      await logQuery("vault_semantic_search", query, results, {
+      const envelope = applyCharBudget(results, maxChars);
+      await logQuery("vault_semantic_search", query, envelope.results, {
         limit,
         folder,
         tag,
@@ -263,9 +277,10 @@ if (embeddingsDb) {
         hyde,
         includeDeprecated,
         staleWeight,
+        maxChars,
       });
       return {
-        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
       };
     })
   );
@@ -274,7 +289,7 @@ if (embeddingsDb) {
     "vault_search_chunks",
     {
       description:
-        "Search vault at the paragraph/section level. Returns the most semantically similar chunks (not whole notes), each with its heading breadcrumb (e.g. 'ADR-001 > Rationale > Why Workers'), the chunk text itself, any wiki-links it contains, and a similarity score. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: chunks from deprecated notes are excluded and chunks from stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use this when you want just the relevant passage — much cheaper than reading whole notes. Follow up with vault_read if the surrounding file context matters.",
+        "Search vault at the paragraph/section level. Returns the most semantically similar chunks (not whole notes), each with its heading breadcrumb (e.g. 'ADR-001 > Rationale > Why Workers'), the chunk text itself, any wiki-links it contains, and a similarity score. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: chunks from deprecated notes are excluded and chunks from stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use this when you want just the relevant passage — much cheaper than reading whole notes. Follow up with vault_read if the surrounding file context matters. Response shape: `{ results, truncated }` — lower-ranked chunks are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top chunk is always returned even if its text alone exceeds the budget.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
@@ -285,9 +300,10 @@ if (embeddingsDb) {
         hyde: z.boolean().optional(),
         includeDeprecated: z.boolean().optional(),
         staleWeight: z.number().min(0).max(1).optional(),
+        maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
       },
     },
-    safe(async ({ query, limit, folder, tag, after, before, hyde, includeDeprecated, staleWeight }) => {
+    safe(async ({ query, limit, folder, tag, after, before, hyde, includeDeprecated, staleWeight, maxChars }) => {
       await embeddingsReady;
       if (!embeddingsDb) {
         return {
@@ -305,7 +321,8 @@ if (embeddingsDb) {
         includeDeprecated,
         staleWeight,
       });
-      await logQuery("vault_search_chunks", query, results, {
+      const envelope = applyCharBudget(results, maxChars);
+      await logQuery("vault_search_chunks", query, envelope.results, {
         limit,
         folder,
         tag,
@@ -314,9 +331,10 @@ if (embeddingsDb) {
         hyde,
         includeDeprecated,
         staleWeight,
+        maxChars,
       });
       return {
-        content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
       };
     })
   );

--- a/test/budgets.test.js
+++ b/test/budgets.test.js
@@ -8,11 +8,13 @@
  *  - single top item over budget (at-least-one-result contract)
  *  - empty input
  *  - very large maxChars
- *  - exact-boundary equality
+ *  - exact-boundary equality (wrapper + commas accounted for)
+ *  - zod schema validation of the `maxChars` input field
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { applyCharBudget } from "../lib/budgets.js";
+import { z } from "zod";
+import { applyCharBudget, WRAPPER_OVERHEAD, DEFAULT_MAX_CHARS } from "../lib/budgets.js";
 
 function sized(id, bytes) {
   // Build an item whose JSON.stringify(item).length equals `bytes` exactly.
@@ -37,8 +39,10 @@ describe("applyCharBudget", () => {
 
   it("drops from the bottom when over budget", () => {
     const items = [sized("a", 40), sized("b", 40), sized("c", 40), sized("d", 40)];
-    // Budget fits two items (80) but not three (120).
-    const out = applyCharBudget(items, 100);
+    // Two items = 40 + 1 (comma) + 40 = 81 bytes of payload.
+    // Three items = 40*3 + 2 (commas) = 122. Budget must be between 81+40 and 122+40.
+    // Pick 140 → effective 100, fits 2 (81) but not 3 (122).
+    const out = applyCharBudget(items, 140);
     assert.equal(out.truncated, true);
     assert.equal(out.results.length, 2);
     assert.deepEqual(
@@ -72,11 +76,12 @@ describe("applyCharBudget", () => {
     assert.equal(out.results.length, 50);
   });
 
-  it("does not truncate when budget exactly equals total size", () => {
+  it("does not truncate when budget exactly equals total size including overhead", () => {
     const a = sized("a", 30);
     const b = sized("b", 30);
     const c = sized("c", 30);
-    const total = 30 + 30 + 30;
+    // Payload = 30 + 1 + 30 + 1 + 30 = 92 bytes; plus WRAPPER_OVERHEAD.
+    const total = 92 + WRAPPER_OVERHEAD;
     const out = applyCharBudget([a, b, c], total);
     assert.equal(out.truncated, false);
     assert.equal(out.results.length, 3);
@@ -86,8 +91,55 @@ describe("applyCharBudget", () => {
     const a = sized("a", 30);
     const b = sized("b", 30);
     const c = sized("c", 30);
-    const out = applyCharBudget([a, b, c], 89);
+    // Payload = 92; 1 byte below fits only 2 items (30 + 1 + 30 = 61).
+    const out = applyCharBudget([a, b, c], 91 + WRAPPER_OVERHEAD);
     assert.equal(out.truncated, true);
     assert.equal(out.results.length, 2);
+  });
+
+  it("accounts for comma separators (N items = sum(sizes) + N-1 commas)", () => {
+    // Three 30-byte items: serialized array payload = 30+1+30+1+30 = 92, not 90.
+    const items = [sized("a", 30), sized("b", 30), sized("c", 30)];
+    // Budget fits 90 bytes of items + overhead, but the 2 commas push total to 92.
+    const out = applyCharBudget(items, 90 + WRAPPER_OVERHEAD);
+    assert.equal(out.truncated, true);
+    assert.ok(out.results.length < 3);
+  });
+});
+
+describe("maxChars zod schema", () => {
+  // Mirrors the schema used in lib/mcp.js input definitions for the four
+  // search/list tools: z.number().int().positive().optional().default(8000).
+  const schema = z.number().int().positive().optional().default(DEFAULT_MAX_CHARS);
+
+  it("rejects zero", () => {
+    assert.equal(schema.safeParse(0).success, false);
+  });
+
+  it("rejects negative integers", () => {
+    assert.equal(schema.safeParse(-1).success, false);
+  });
+
+  it("rejects non-integers", () => {
+    assert.equal(schema.safeParse(3.5).success, false);
+  });
+
+  it("accepts 1", () => {
+    const r = schema.safeParse(1);
+    assert.equal(r.success, true);
+    assert.equal(r.data, 1);
+  });
+
+  it("accepts 8000", () => {
+    const r = schema.safeParse(8000);
+    assert.equal(r.success, true);
+    assert.equal(r.data, 8000);
+  });
+
+  it("applies the default when absent", () => {
+    const r = schema.safeParse(undefined);
+    assert.equal(r.success, true);
+    assert.equal(r.data, DEFAULT_MAX_CHARS);
+    assert.equal(r.data, 8000);
   });
 });

--- a/test/budgets.test.js
+++ b/test/budgets.test.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Char-budget helper assertions — issue #30.
+ *
+ * Covers the envelope contract for the four search tools:
+ *  - under-budget passthrough
+ *  - drop-from-bottom when over budget
+ *  - single top item over budget (at-least-one-result contract)
+ *  - empty input
+ *  - very large maxChars
+ *  - exact-boundary equality
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applyCharBudget } from "../lib/budgets.js";
+
+function sized(id, bytes) {
+  // Build an item whose JSON.stringify(item).length equals `bytes` exactly.
+  // Skeleton: {"id":"X","pad":"..."} — measure skeleton then pad the string.
+  const skeleton = JSON.stringify({ id, pad: "" });
+  const padLen = bytes - skeleton.length;
+  if (padLen < 0) throw new Error(`bytes ${bytes} too small for id ${id}`);
+  return { id, pad: "x".repeat(padLen) };
+}
+
+describe("applyCharBudget", () => {
+  it("returns envelope with truncated:false when under budget", () => {
+    const items = [sized("a", 50), sized("b", 50), sized("c", 50)];
+    const out = applyCharBudget(items, 1000);
+    assert.equal(out.truncated, false);
+    assert.equal(out.results.length, 3);
+    assert.deepEqual(
+      out.results.map((r) => r.id),
+      ["a", "b", "c"]
+    );
+  });
+
+  it("drops from the bottom when over budget", () => {
+    const items = [sized("a", 40), sized("b", 40), sized("c", 40), sized("d", 40)];
+    // Budget fits two items (80) but not three (120).
+    const out = applyCharBudget(items, 100);
+    assert.equal(out.truncated, true);
+    assert.equal(out.results.length, 2);
+    assert.deepEqual(
+      out.results.map((r) => r.id),
+      ["a", "b"]
+    );
+  });
+
+  it("returns the top item even when it alone exceeds the budget", () => {
+    const items = [sized("a", 500), sized("b", 20)];
+    const out = applyCharBudget(items, 100);
+    assert.equal(out.truncated, true);
+    assert.equal(out.results.length, 1);
+    assert.equal(out.results[0].id, "a");
+  });
+
+  it("returns empty envelope on empty input", () => {
+    const out = applyCharBudget([], 1000);
+    assert.deepEqual(out, { results: [], truncated: false });
+  });
+
+  it("also handles non-array input gracefully", () => {
+    assert.deepEqual(applyCharBudget(undefined, 1000), { results: [], truncated: false });
+    assert.deepEqual(applyCharBudget(null, 1000), { results: [], truncated: false });
+  });
+
+  it("does not truncate when maxChars is very large", () => {
+    const items = Array.from({ length: 50 }, (_, i) => sized(`n${i}`, 100));
+    const out = applyCharBudget(items, 10_000_000);
+    assert.equal(out.truncated, false);
+    assert.equal(out.results.length, 50);
+  });
+
+  it("does not truncate when budget exactly equals total size", () => {
+    const a = sized("a", 30);
+    const b = sized("b", 30);
+    const c = sized("c", 30);
+    const total = 30 + 30 + 30;
+    const out = applyCharBudget([a, b, c], total);
+    assert.equal(out.truncated, false);
+    assert.equal(out.results.length, 3);
+  });
+
+  it("truncates when total overshoots by a single byte", () => {
+    const a = sized("a", 30);
+    const b = sized("b", 30);
+    const c = sized("c", 30);
+    const out = applyCharBudget([a, b, c], 89);
+    assert.equal(out.truncated, true);
+    assert.equal(out.results.length, 2);
+  });
+});


### PR DESCRIPTION
## Summary

Four MCP search tools — \`vault_search\`, \`vault_list\`, \`vault_semantic_search\`, \`vault_search_chunks\` — now return a \`{ results, truncated }\` envelope and honor a per-call \`maxChars\` budget (default 8000 chars ≈ 2000 tokens). Results are trimmed from the bottom (list is pre-ranked); the top result is always returned even if it alone exceeds the budget (at-least-one-result contract).

Closes #30.

## Breaking change

The four tools above previously returned a bare JSON array. They now return \`{ results: [...], truncated: boolean }\`. MCP consumers that destructure the response must be updated. The \`*_with_context\` tools already used this shape — this aligns the rest of the surface.

## Required next release: minor bump to 0.3.0

Per user direction, this breaking change justifies a **minor bump to 0.3.0** at the next release. \`package.json\` is intentionally **not** bumped in this PR — that belongs to the release-manager.

## Changes

- \`lib/budgets.js\` (new): \`applyCharBudget(items, maxChars)\` helper. Drops from the bottom, accounts with \`JSON.stringify(item).length\`, honors at-least-one-result.
- \`lib/mcp.js\`: wires the helper into the four search tools; adds \`maxChars: z.number().int().positive().optional().default(8000)\` to each input schema; updates tool descriptions.
- \`test/budgets.test.js\` (new): 8 assertions covering under-budget, drop-from-bottom, single-over-budget, empty input, non-array input, very-large budget, exact boundary, and single-byte overshoot.
- \`README.md\`: documents the envelope + \`maxChars\` contract.

## Verification

- [x] \`npm install --no-audit --no-fund\` cold
- [x] \`node --test test/budgets.test.js\` — 8 pass
- [x] \`node --test test/\` — 15 pass, 0 fail
- [x] \`node --check lib/mcp.js\` clean
- [x] MCP stdio boot with \`VAULT_DIR=./vault/claude-code-vault\` — no crash
- [x] End-to-end: \`tools/call vault_search\` with \`maxChars: 200\` returns \`{ results:[1], truncated: true }\` (496 bytes); unbounded returns \`{ results:[3], truncated: false }\` (1599 bytes)
- [x] \`node index.js lint --format github\` — no new findings (pre-existing runbook warnings unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)