### PR TITLE
feat: vault_tour + vault_outline MCP tools (closes #29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd web && npm install && cd ..
 
       - name: Type check (CLI)
-        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js test/section-edit.test.js test/stubs-and-suggestions.test.js test/query-log.test.js test/glossary.test.js
+        run: npx tsc --noEmit --allowJs --skipLibCheck index.js lib/*.js test/retrieval/eval.js test/retrieval/status_filter.test.js test/vault-write.test.js test/section-edit.test.js test/stubs-and-suggestions.test.js test/query-log.test.js test/glossary.test.js test/tour-outline.test.js
 
       - name: Type check (web)
         run: cd web && npx tsc --noEmit && cd ..
@@ -67,6 +67,9 @@ jobs:
 
       - name: Glossary resolution assertions
         run: node test/glossary.test.js
+
+      - name: Tour + outline assertions
+        run: node test/tour-outline.test.js
 
       - name: Lint web (if eslintrc exists)
         run: cd web && npm run lint 2>/dev/null || echo "No lint script defined"

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -21,15 +21,22 @@ function isSeedId(id) {
 
 /**
  * Build outbound edges (active targets only) and inbound-degree map.
+ *
+ * Repeated wiki-links from the same source are collapsed to a single edge,
+ * so a body that mentions `[[demo/hub]]` five times contributes exactly one
+ * unit of inbound-degree to `demo/hub`. This keeps PageRank proportional to
+ * editorial structure, not prose repetition.
  */
 function buildEdges(active, activeIds) {
   const outbound = new Map();
   const inboundDegree = new Map();
   for (const note of active) {
     const links = Array.isArray(note.links) ? note.links : [];
-    const valid = links.filter((l) => activeIds.has(l) && l !== note.id);
-    outbound.set(note.id, valid);
-    for (const target of valid) {
+    const unique = Array.from(
+      new Set(links.filter((l) => activeIds.has(l) && l !== note.id))
+    );
+    outbound.set(note.id, unique);
+    for (const target of unique) {
       inboundDegree.set(target, (inboundDegree.get(target) || 0) + 1);
     }
   }

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -4,6 +4,145 @@ import path from "path";
 const FALLBACK_SNIPPET_CHARS = 400;
 const MIN_VIABLE_SNIPPET = 100;
 
+const PAGERANK_DAMPING = 0.85;
+const PAGERANK_MAX_ITERS = 30;
+const PAGERANK_TOLERANCE = 1e-6;
+const STALE_MULTIPLIER = 0.7;
+const SEED_BIAS = 3;
+const PAGERANK_BLEND = 0.7; // 70% PageRank, 30% inbound-degree
+
+function isSeedId(id) {
+  if (!id) return false;
+  const lower = id.toLowerCase();
+  if (lower === "vault-summary" || lower === "overview") return true;
+  if (lower.endsWith("/overview")) return true;
+  return /(^|\/)vault[_-]?summary$/i.test(id);
+}
+
+/**
+ * Build outbound edges (active targets only) and inbound-degree map.
+ */
+function buildEdges(active, activeIds) {
+  const outbound = new Map();
+  const inboundDegree = new Map();
+  for (const note of active) {
+    const links = Array.isArray(note.links) ? note.links : [];
+    const valid = links.filter((l) => activeIds.has(l) && l !== note.id);
+    outbound.set(note.id, valid);
+    for (const target of valid) {
+      inboundDegree.set(target, (inboundDegree.get(target) || 0) + 1);
+    }
+  }
+  return { outbound, inboundDegree };
+}
+
+/**
+ * Seeded teleport distribution: seeds get SEED_BIAS× weight.
+ */
+function buildTeleport(active) {
+  const teleport = new Map();
+  let total = 0;
+  for (const note of active) {
+    const w = isSeedId(note.id) ? SEED_BIAS : 1;
+    teleport.set(note.id, w);
+    total += w;
+  }
+  for (const [id, w] of teleport) teleport.set(id, w / total);
+  return teleport;
+}
+
+/**
+ * One PageRank iteration. Returns `{ next, delta }`.
+ * Dangling-node rank is redistributed proportional to teleport so total
+ * probability mass is conserved.
+ */
+function iterateRank(active, outbound, teleport, rank) {
+  const next = new Map();
+  for (const note of active) {
+    next.set(note.id, (1 - PAGERANK_DAMPING) * teleport.get(note.id));
+  }
+  let danglingMass = 0;
+  for (const note of active) {
+    const outs = outbound.get(note.id);
+    const r = rank.get(note.id);
+    if (!outs || outs.length === 0) {
+      danglingMass += r;
+      continue;
+    }
+    const share = (PAGERANK_DAMPING * r) / outs.length;
+    for (const target of outs) {
+      next.set(target, (next.get(target) || 0) + share);
+    }
+  }
+  if (danglingMass > 0) {
+    for (const note of active) {
+      next.set(
+        note.id,
+        (next.get(note.id) || 0) + PAGERANK_DAMPING * danglingMass * teleport.get(note.id)
+      );
+    }
+  }
+  let delta = 0;
+  for (const [id, r] of next) delta += Math.abs(r - (rank.get(id) || 0));
+  return { next, delta };
+}
+
+/**
+ * Blend PageRank with normalized inbound-degree, apply stale penalty.
+ */
+function blendScores(active, rank, inboundDegree) {
+  let maxInbound = 0;
+  for (const v of inboundDegree.values()) if (v > maxInbound) maxInbound = v;
+  const N = Math.max(1, active.length);
+  const blended = new Map();
+  for (const note of active) {
+    const pr = rank.get(note.id) || 0;
+    const inDeg = inboundDegree.get(note.id) || 0;
+    const normIn = maxInbound > 0 ? inDeg / maxInbound : 0;
+    let score = PAGERANK_BLEND * pr + (1 - PAGERANK_BLEND) * (normIn / N);
+    if (note.status === "stale") score *= STALE_MULTIPLIER;
+    blended.set(note.id, score);
+  }
+  return blended;
+}
+
+/**
+ * Compute blended importance scores for every non-deprecated note in the
+ * vault. Combines iterative PageRank (damping 0.85, ≤30 iters) with 1-hop
+ * inbound-degree so actual content hubs surface even when VAULT_SUMMARY is
+ * thin. Seeds (`VAULT_SUMMARY*` / `overview*`) get a teleport bias so new
+ * sessions land on orientation notes first. Stale notes are downweighted
+ * post-hoc by 0.7× (matching Vault.search). Deprecated notes are excluded
+ * from both the ranking and the graph.
+ *
+ * Returns a Map<noteId, score>. Empty vaults / vaults with no edges return
+ * an empty Map (no throws).
+ *
+ * Pure JS, no deps. Complexity O(iters * edges) — fine for <50k edges.
+ */
+export function computePageRank(vault) {
+  const empty = new Map();
+  if (!vault || !Array.isArray(vault.index) || vault.index.length === 0) return empty;
+
+  const active = vault.index.filter((n) => n.status !== "deprecated");
+  if (active.length === 0) return empty;
+
+  const activeIds = new Set(active.map((n) => n.id));
+  const { outbound, inboundDegree } = buildEdges(active, activeIds);
+  const teleport = buildTeleport(active);
+
+  let rank = new Map();
+  for (const note of active) rank.set(note.id, 1 / active.length);
+
+  for (let iter = 0; iter < PAGERANK_MAX_ITERS; iter++) {
+    const { next, delta } = iterateRank(active, outbound, teleport, rank);
+    rank = next;
+    if (delta < PAGERANK_TOLERANCE) break;
+  }
+
+  return blendScores(active, rank, inboundDegree);
+}
+
 function computeFrequencies(db, anchorIds) {
   const forwardFreq = new Map();
   const backlinkFreq = new Map();

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -13,7 +13,7 @@ import { appendEntry, isLoggingEnabled } from "./query-log.js";
 import { applyCharBudget, DEFAULT_MAX_CHARS } from "./budgets.js";
 import { buildGlossary, resolveJargon } from "./glossary.js";
 import { computePageRank } from "./graph.js";
-import { extractOutline } from "./outline.js";
+import { extractOutline, renderOutlineBlock, fitOutlineBlocks } from "./outline.js";
 import fs from "node:fs/promises";
 
 const require = createRequire(import.meta.url);
@@ -493,34 +493,22 @@ if (embeddingsDb) {
   );
 }
 
-function normalizeProjectPrefix(project) {
-  if (!project) return null;
-  return project.endsWith("/") ? project : project + "/";
+function normalizeFolderPrefix(folder) {
+  if (!folder) return null;
+  return folder.endsWith("/") ? folder : folder + "/";
 }
 
-function matchesProject(noteId, project, prefix) {
+function matchesFolder(noteId, folder, prefix) {
   if (!prefix) return true;
-  return noteId === project || noteId.startsWith(prefix);
+  return noteId === folder || noteId.startsWith(prefix);
 }
 
-function selectNotes(vault, project) {
-  const prefix = normalizeProjectPrefix(project);
+function selectNotes(vault, folder) {
+  const prefix = normalizeFolderPrefix(folder);
   return vault.index.filter((n) => {
     if (n.status === "deprecated") return false;
-    return matchesProject(n.id, project, prefix);
+    return matchesFolder(n.id, folder, prefix);
   });
-}
-
-function renderOutlineBlock(note, headings) {
-  const lines = [`# ${note.title} (${note.id})`];
-  // Skip body H1s — the synthetic title line already acts as the H1.
-  for (const h of headings) {
-    if (h.level <= 1) continue;
-    const pad = "  ".repeat(Math.max(0, h.level - 1));
-    const hashes = "#".repeat(h.level);
-    lines.push(`${pad}${hashes} ${h.text}`);
-  }
-  return lines.join("\n");
 }
 
 async function buildOutlineBlock(note, depth) {
@@ -533,38 +521,20 @@ async function buildOutlineBlock(note, depth) {
   return renderOutlineBlock(note, extractOutline(raw, depth));
 }
 
-function fitOutlineBlocks(blocks, budget) {
-  let text = "";
-  let included = 0;
-  for (const block of blocks) {
-    const next = included === 0 ? block : text + "\n\n" + block;
-    if (next.length > budget && included > 0) break;
-    text = next;
-    included += 1;
-  }
-  const omitted = blocks.length - included;
-  if (omitted > 0) {
-    const suffix = omitted === 1 ? "" : "s";
-    text += `\n\n[truncated: ${omitted} note${suffix} omitted]`;
-  }
-  if (blocks.length === 0) text = "";
-  return text;
-}
-
 server.registerTool(
   "vault_tour",
   {
     description:
-      "Return the top-`limit` most important notes in the vault, ranked by graph centrality (PageRank, damping 0.85, blended 70/30 with inbound-degree). Use at the start of a new session to orient an agent in the vault without walking links manually. Deprecated notes are excluded; stale notes are downweighted (0.7×). VAULT_SUMMARY / overview notes get a seed bias so new sessions land on orientation first. `project` is an optional id-prefix filter (e.g. 'claude-code-vault' — matches any note whose id begins with that prefix, consistent with `folder` on vault_semantic_search). Response shape: `{ results, truncated }`. Each result: `{ id, title, summary, type, pageRank, status }`. Default `limit` 10. Bounded by `maxChars` (default 8000 ≈ 2000 tokens).",
+      "Return the top-`limit` most important notes in the vault, ranked by graph centrality (PageRank, damping 0.85, blended 70/30 with inbound-degree). Use at the start of a new session to orient an agent in the vault without walking links manually. Deprecated notes are excluded; stale notes are downweighted (0.7×). VAULT_SUMMARY / overview notes get a seed bias so new sessions land on orientation first. `folder` is an optional id-prefix filter (e.g. 'claude-code-vault' — matches any note whose id begins with that prefix, consistent with `folder` on vault_semantic_search). Response shape: `{ results, truncated }`. Each result: `{ id, title, summary, type, pageRank, status }`. Default `limit` 10 (max 200). Bounded by `maxChars` (default 8000 ≈ 2000 tokens).",
     inputSchema: {
-      project: z.string().optional(),
-      limit: z.number().int().positive().optional(),
+      folder: z.string().min(1).optional(),
+      limit: z.number().int().positive().max(200).optional(),
       maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
     },
   },
-  safe(async ({ project, limit, maxChars }) => {
+  safe(async ({ folder, limit, maxChars }) => {
     const take = limit ?? 10;
-    const ranked = selectNotes(vault, project)
+    const ranked = selectNotes(vault, folder)
       .map((n) => ({
         id: n.id,
         title: n.title,
@@ -589,26 +559,31 @@ server.registerTool(
   "vault_outline",
   {
     description:
-      "Return a plain-text table of contents for the vault — each note's title + top `maxDepth` heading levels. Cheap, skimmable, no JSON parsing required. Use to understand the shape of a project without reading full notes. Structure per note: a `# title (id)` line followed by indented `##`/`###` headings. Deprecated notes are excluded. `project` is an optional id-prefix filter. Default `maxDepth` 2 (H2 only below the title line). Headings inside fenced code blocks are skipped. Truncation: if the outline exceeds `maxChars` (default 8000), it is cut at a whole-note boundary and a trailing `[truncated: N notes omitted]` marker is appended. Returns a single `text/plain` content item.",
+      "Return a plain-text table of contents for the vault — each note's title + top `maxDepth` heading levels. Cheap, skimmable, no JSON parsing required. Use to understand the shape of a folder without reading full notes. Structure per note: a `# title (id)` line followed by indented `##`/`###` headings. Deprecated notes are excluded. `folder` is an optional id-prefix filter (consistent with `folder` on vault_semantic_search). Default `maxDepth` 2 (H2 only below the title line). Headings inside fenced code blocks are skipped. Response shape: `{ outline, truncated, noteCount }` — `outline` is the packed markdown text; if it exceeds `maxChars` (default 8000) it is cut at a whole-note boundary with a trailing `[truncated: N notes omitted]` marker and `truncated` is `true`.",
     inputSchema: {
-      project: z.string().optional(),
+      folder: z.string().min(1).optional(),
       maxDepth: z.number().int().min(1).max(6).optional(),
       maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
     },
   },
-  safe(async ({ project, maxDepth, maxChars }) => {
+  safe(async ({ folder, maxDepth, maxChars }) => {
     const depth = maxDepth ?? 2;
-    const selected = selectNotes(vault, project)
+    const selected = selectNotes(vault, folder)
       .slice()
       .sort((a, b) => a.id.localeCompare(b.id));
     const budget =
       Number.isFinite(maxChars) && maxChars > 0 ? maxChars : DEFAULT_MAX_CHARS;
-    const blocks = [];
-    for (const note of selected) {
-      blocks.push(await buildOutlineBlock(note, depth));
-    }
+    const blocks = await Promise.all(
+      selected.map((n) => buildOutlineBlock(n, depth))
+    );
+    const { text, included, omitted } = fitOutlineBlocks(blocks, budget);
+    const envelope = {
+      outline: text,
+      truncated: omitted > 0,
+      noteCount: included,
+    };
     return {
-      content: [{ type: "text", text: fitOutlineBlocks(blocks, budget) }],
+      content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
     };
   })
 );

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -12,6 +12,9 @@ import { createNote, writeNote, editSection } from "./vault-write.js";
 import { appendEntry, isLoggingEnabled } from "./query-log.js";
 import { applyCharBudget, DEFAULT_MAX_CHARS } from "./budgets.js";
 import { buildGlossary, resolveJargon } from "./glossary.js";
+import { computePageRank } from "./graph.js";
+import { extractOutline } from "./outline.js";
+import fs from "node:fs/promises";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
@@ -37,6 +40,12 @@ try {
   glossary = await buildGlossary(vault);
 } catch (e) {
   console.error("initial glossary build failed:", e.message);
+}
+let pageRankScores = new Map();
+try {
+  pageRankScores = computePageRank(vault);
+} catch (e) {
+  console.error("initial pagerank build failed:", e.message);
 }
 
 const cacheDir = path.resolve(vaultDir, "..", ".vault-cache");
@@ -71,6 +80,11 @@ const scheduleReindex = () => {
     try {
       await vault.reindex();
       glossary = await buildGlossary(vault);
+      try {
+        pageRankScores = computePageRank(vault);
+      } catch (e) {
+        console.error("pagerank rebuild failed:", e.message);
+      }
       if (embeddingsDb && syncEmbeddings) await syncEmbeddings(embeddingsDb, vault);
     } catch (e) {
       console.error("reindex failed:", e);
@@ -479,8 +493,138 @@ if (embeddingsDb) {
   );
 }
 
+function normalizeProjectPrefix(project) {
+  if (!project) return null;
+  return project.endsWith("/") ? project : project + "/";
+}
+
+function matchesProject(noteId, project, prefix) {
+  if (!prefix) return true;
+  return noteId === project || noteId.startsWith(prefix);
+}
+
+function selectNotes(vault, project) {
+  const prefix = normalizeProjectPrefix(project);
+  return vault.index.filter((n) => {
+    if (n.status === "deprecated") return false;
+    return matchesProject(n.id, project, prefix);
+  });
+}
+
+function renderOutlineBlock(note, headings) {
+  const lines = [`# ${note.title} (${note.id})`];
+  // Skip body H1s — the synthetic title line already acts as the H1.
+  for (const h of headings) {
+    if (h.level <= 1) continue;
+    const pad = "  ".repeat(Math.max(0, h.level - 1));
+    const hashes = "#".repeat(h.level);
+    lines.push(`${pad}${hashes} ${h.text}`);
+  }
+  return lines.join("\n");
+}
+
+async function buildOutlineBlock(note, depth) {
+  let raw = "";
+  try {
+    raw = await fs.readFile(path.join(vault.vaultDir, note.path), "utf-8");
+  } catch {
+    raw = "";
+  }
+  return renderOutlineBlock(note, extractOutline(raw, depth));
+}
+
+function fitOutlineBlocks(blocks, budget) {
+  let text = "";
+  let included = 0;
+  for (const block of blocks) {
+    const next = included === 0 ? block : text + "\n\n" + block;
+    if (next.length > budget && included > 0) break;
+    text = next;
+    included += 1;
+  }
+  const omitted = blocks.length - included;
+  if (omitted > 0) {
+    const suffix = omitted === 1 ? "" : "s";
+    text += `\n\n[truncated: ${omitted} note${suffix} omitted]`;
+  }
+  if (blocks.length === 0) text = "";
+  return text;
+}
+
+server.registerTool(
+  "vault_tour",
+  {
+    description:
+      "Return the top-`limit` most important notes in the vault, ranked by graph centrality (PageRank, damping 0.85, blended 70/30 with inbound-degree). Use at the start of a new session to orient an agent in the vault without walking links manually. Deprecated notes are excluded; stale notes are downweighted (0.7×). VAULT_SUMMARY / overview notes get a seed bias so new sessions land on orientation first. `project` is an optional id-prefix filter (e.g. 'claude-code-vault' — matches any note whose id begins with that prefix, consistent with `folder` on vault_semantic_search). Response shape: `{ results, truncated }`. Each result: `{ id, title, summary, type, pageRank, status }`. Default `limit` 10. Bounded by `maxChars` (default 8000 ≈ 2000 tokens).",
+    inputSchema: {
+      project: z.string().optional(),
+      limit: z.number().int().positive().optional(),
+      maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
+    },
+  },
+  safe(async ({ project, limit, maxChars }) => {
+    const take = limit ?? 10;
+    const ranked = selectNotes(vault, project)
+      .map((n) => ({
+        id: n.id,
+        title: n.title,
+        summary: n.summary ?? null,
+        type: n.type ?? null,
+        pageRank: pageRankScores.get(n.id) ?? 0,
+        status: n.status ?? "current",
+      }))
+      .sort((a, b) => {
+        if (b.pageRank !== a.pageRank) return b.pageRank - a.pageRank;
+        return a.id.localeCompare(b.id);
+      })
+      .slice(0, take);
+    const envelope = applyCharBudget(ranked, maxChars);
+    return {
+      content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
+    };
+  })
+);
+
+server.registerTool(
+  "vault_outline",
+  {
+    description:
+      "Return a plain-text table of contents for the vault — each note's title + top `maxDepth` heading levels. Cheap, skimmable, no JSON parsing required. Use to understand the shape of a project without reading full notes. Structure per note: a `# title (id)` line followed by indented `##`/`###` headings. Deprecated notes are excluded. `project` is an optional id-prefix filter. Default `maxDepth` 2 (H2 only below the title line). Headings inside fenced code blocks are skipped. Truncation: if the outline exceeds `maxChars` (default 8000), it is cut at a whole-note boundary and a trailing `[truncated: N notes omitted]` marker is appended. Returns a single `text/plain` content item.",
+    inputSchema: {
+      project: z.string().optional(),
+      maxDepth: z.number().int().min(1).max(6).optional(),
+      maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
+    },
+  },
+  safe(async ({ project, maxDepth, maxChars }) => {
+    const depth = maxDepth ?? 2;
+    const selected = selectNotes(vault, project)
+      .slice()
+      .sort((a, b) => a.id.localeCompare(b.id));
+    const budget =
+      Number.isFinite(maxChars) && maxChars > 0 ? maxChars : DEFAULT_MAX_CHARS;
+    const blocks = [];
+    for (const note of selected) {
+      blocks.push(await buildOutlineBlock(note, depth));
+    }
+    return {
+      content: [{ type: "text", text: fitOutlineBlocks(blocks, budget) }],
+    };
+  })
+);
+
 async function resyncAfterWrite() {
   await vault.reindex();
+  try {
+    glossary = await buildGlossary(vault);
+  } catch (e) {
+    console.error("post-write glossary rebuild failed:", e.message);
+  }
+  try {
+    pageRankScores = computePageRank(vault);
+  } catch (e) {
+    console.error("post-write pagerank rebuild failed:", e.message);
+  }
   if (embeddingsDb && syncEmbeddings) {
     try {
       await syncEmbeddings(embeddingsDb, vault);

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -1,15 +1,17 @@
 /**
- * Pure heading extraction for `vault_outline` (issue #29).
+ * Outline extraction + rendering helpers for `vault_outline` (issue #29).
  *
- * Given a markdown body, returns the heading skeleton — `[{ level, text }]`
- * — up to `maxDepth`. Headings inside fenced code blocks are skipped
- * (both ``` and ~~~ fences), mirroring the fence-stripping pattern in
- * `lib/vault.js._extractBacklinks` and `lib/glossary.js`.
+ * Exposes three pure functions:
+ *   - `extractOutline(md, maxDepth)` — ATX heading skeleton, fence-aware.
+ *   - `renderOutlineBlock(note, headings)` — single-note markdown block.
+ *   - `fitOutlineBlocks(blocks, budget)` — pack blocks under a char budget,
+ *     preserving a whole-note boundary and emitting a truncation marker.
  *
  * Frontmatter at the top of the file is ignored. ATX-style headings only
  * (`# heading`, `## heading`, etc). Setext-style (underlined) headings are
  * intentionally not supported — no note in the vault uses them and they
- * would complicate the scanner.
+ * would complicate the scanner. Fence-stripping mirrors the pattern in
+ * `lib/vault.js._extractBacklinks` and `lib/glossary.js`.
  */
 
 const MAX_ATX_DEPTH = 6;
@@ -49,7 +51,8 @@ export function extractOutline(markdown, maxDepth = 2) {
       continue;
     }
     if (fence !== null) continue;
-    const h = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+    // Commonmark permits up to 3 leading spaces before the opening '#'.
+    const h = line.match(/^ {0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
     if (!h) continue;
     const level = h[1].length;
     if (level > depth) continue;
@@ -58,4 +61,57 @@ export function extractOutline(markdown, maxDepth = 2) {
     headings.push({ level, text });
   }
   return headings;
+}
+
+/**
+ * Render a single note's outline block: a synthetic `# title (id)` line
+ * followed by indented markdown headings (H2+, since the title line already
+ * acts as the H1). Level-1 headings from the body are skipped to avoid
+ * duplicating the title.
+ *
+ * @param {{ id: string, title: string }} note
+ * @param {Array<{ level: number, text: string }>} headings
+ * @returns {string}
+ */
+export function renderOutlineBlock(note, headings) {
+  const lines = [`# ${note.title} (${note.id})`];
+  for (const h of headings) {
+    if (h.level <= 1) continue;
+    const pad = "  ".repeat(Math.max(0, h.level - 1));
+    const hashes = "#".repeat(h.level);
+    lines.push(`${pad}${hashes} ${h.text}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Pack rendered outline blocks into a single string under `budget` chars.
+ * The first block is always included even if it alone exceeds the budget
+ * (at-least-one contract, matches `applyCharBudget`). When any blocks are
+ * dropped, a `[truncated: N note(s) omitted]` marker is appended at a
+ * whole-note boundary.
+ *
+ * Returns both the packed text and the count of notes actually included,
+ * so callers can build an envelope ({ outline, truncated, noteCount }).
+ *
+ * @param {string[]} blocks
+ * @param {number} budget
+ * @returns {{ text: string, included: number, omitted: number }}
+ */
+export function fitOutlineBlocks(blocks, budget) {
+  if (blocks.length === 0) return { text: "", included: 0, omitted: 0 };
+  let text = "";
+  let included = 0;
+  for (const block of blocks) {
+    const next = included === 0 ? block : text + "\n\n" + block;
+    if (next.length > budget && included > 0) break;
+    text = next;
+    included += 1;
+  }
+  const omitted = blocks.length - included;
+  if (omitted > 0) {
+    const suffix = omitted === 1 ? "" : "s";
+    text += `\n\n[truncated: ${omitted} note${suffix} omitted]`;
+  }
+  return { text, included, omitted };
 }

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -1,0 +1,61 @@
+/**
+ * Pure heading extraction for `vault_outline` (issue #29).
+ *
+ * Given a markdown body, returns the heading skeleton — `[{ level, text }]`
+ * — up to `maxDepth`. Headings inside fenced code blocks are skipped
+ * (both ``` and ~~~ fences), mirroring the fence-stripping pattern in
+ * `lib/vault.js._extractBacklinks` and `lib/glossary.js`.
+ *
+ * Frontmatter at the top of the file is ignored. ATX-style headings only
+ * (`# heading`, `## heading`, etc). Setext-style (underlined) headings are
+ * intentionally not supported — no note in the vault uses them and they
+ * would complicate the scanner.
+ */
+
+const MAX_ATX_DEPTH = 6;
+
+function stripFrontmatter(markdown) {
+  const match = markdown.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  return match ? markdown.slice(match[0].length) : markdown;
+}
+
+/**
+ * Extract ATX headings up to `maxDepth` from a markdown body.
+ * Skips headings inside fenced code blocks (``` or ~~~, any indent <4 sp).
+ *
+ * @param {string} markdown
+ * @param {number} maxDepth  maximum heading level to include (default 2)
+ * @returns {Array<{ level: number, text: string }>}
+ */
+export function extractOutline(markdown, maxDepth = 2) {
+  if (typeof markdown !== "string" || markdown.length === 0) return [];
+  const depth = Math.max(1, Math.min(MAX_ATX_DEPTH, Number.isFinite(maxDepth) ? maxDepth : 2));
+  const body = stripFrontmatter(markdown);
+  const lines = body.split("\n");
+
+  const headings = [];
+  let fence = null; // null | "`" | "~"
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, "");
+    // Fence open/close. Match at line start (optional up-to-3-space indent).
+    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0];
+      if (fence === null) {
+        fence = char;
+      } else if (fence === char) {
+        fence = null;
+      }
+      continue;
+    }
+    if (fence !== null) continue;
+    const h = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (!h) continue;
+    const level = h[1].length;
+    if (level > depth) continue;
+    const text = h[2].trim();
+    if (text.length === 0) continue;
+    headings.push({ level, text });
+  }
+  return headings;
+}

--- a/test/tour-outline.test.js
+++ b/test/tour-outline.test.js
@@ -4,10 +4,11 @@
  *
  * Exercises:
  *   - computePageRank: monotonicity (hub > leaf), empty vault, deprecated skip,
- *     stale downweight, project prefix filter semantics.
+ *     stale downweight, folder prefix filter semantics, wiki-link dedupe.
  *   - extractOutline: maxDepth, code-fence skipping (``` and ~~~), frontmatter.
  *   - tour envelope respects maxChars (applyCharBudget integration).
- *   - outline truncation marker appears when blocks exceed maxChars.
+ *   - fitOutlineBlocks: truncation marker appears when blocks exceed maxChars;
+ *     at-least-one contract for oversize single block.
  */
 import fs from "fs";
 import fsp from "fs/promises";
@@ -15,7 +16,7 @@ import os from "os";
 import path from "path";
 import { Vault } from "../lib/vault.js";
 import { computePageRank } from "../lib/graph.js";
-import { extractOutline } from "../lib/outline.js";
+import { extractOutline, fitOutlineBlocks } from "../lib/outline.js";
 import { applyCharBudget } from "../lib/budgets.js";
 
 const ROOT = path.join(os.tmpdir(), `vault-tour-outline-${process.pid}`);
@@ -219,7 +220,7 @@ See [[demo/hub]].
     `stale (${staleScore.toFixed(6)}) penalized vs current (${currentScore.toFixed(6)})`
   );
 
-  process.stderr.write("\nproject id-prefix filter semantics\n");
+  process.stderr.write("\nfolder id-prefix filter semantics\n");
   await writeNote(
     "other-proj/note.md",
     `---
@@ -233,27 +234,64 @@ status: current
 `
   );
   vault = await makeVault();
-  // Emulate the mcp filter: prefix = project + "/"; match id === project OR startsWith prefix.
-  const filterByProject = (noteId, project) => {
-    const prefix = project.endsWith("/") ? project : project + "/";
-    return noteId === project || noteId.startsWith(prefix);
+  // Emulate the mcp filter: prefix = folder + "/"; match id === folder OR startsWith prefix.
+  const filterByFolder = (noteId, folder) => {
+    const prefix = folder.endsWith("/") ? folder : folder + "/";
+    return noteId === folder || noteId.startsWith(prefix);
   };
   const demoMatches = vault.index
-    .filter((n) => filterByProject(n.id, "demo"))
+    .filter((n) => filterByFolder(n.id, "demo"))
     .map((n) => n.id);
   assert(
     demoMatches.every((id) => id.startsWith("demo/")),
-    "project=demo matches only demo/* ids"
+    "folder=demo matches only demo/* ids"
   );
   const otherMatches = vault.index
-    .filter((n) => filterByProject(n.id, "other-proj"))
+    .filter((n) => filterByFolder(n.id, "other-proj"))
     .map((n) => n.id);
   assert(
     otherMatches.length === 1 && otherMatches[0] === "other-proj/note",
-    "project=other-proj matches single note"
+    "folder=other-proj matches single note"
   );
-  // No project = no filter: returns all.
+  // No folder = no filter: returns all.
   assert(vault.index.length >= 7, "vault has many notes overall (no filter)");
+
+  process.stderr.write("\ncomputePageRank: repeated wiki-links from same source are deduped\n");
+  // Two isolated mini-vaults: in one, source links to target 1× — in the other, 5×.
+  // The dedupe contract says both should produce the same rank for `target`.
+  const singleRoot = path.join(os.tmpdir(), `vault-dedupe-single-${process.pid}`);
+  const repeatRoot = path.join(os.tmpdir(), `vault-dedupe-repeat-${process.pid}`);
+  for (const root of [singleRoot, repeatRoot]) {
+    if (fs.existsSync(root)) fs.rmSync(root, { recursive: true, force: true });
+    fs.mkdirSync(root, { recursive: true });
+  }
+  const targetBody = `---\nid: target\ntitle: Target\ntype: feature\nstatus: current\n---\n\n# Target\n\nHub.\n`;
+  await fsp.writeFile(path.join(singleRoot, "target.md"), targetBody, "utf-8");
+  await fsp.writeFile(path.join(repeatRoot, "target.md"), targetBody, "utf-8");
+  await fsp.writeFile(
+    path.join(singleRoot, "source.md"),
+    `---\nid: source\ntitle: Source\ntype: feature\nstatus: current\n---\n\n# Source\n\nSee [[target]].\n`,
+    "utf-8"
+  );
+  await fsp.writeFile(
+    path.join(repeatRoot, "source.md"),
+    `---\nid: source\ntitle: Source\ntype: feature\nstatus: current\n---\n\n# Source\n\nSee [[target]] and [[target]] and [[target]] and [[target]] and [[target]].\n`,
+    "utf-8"
+  );
+  const singleVault = new Vault(singleRoot);
+  await singleVault.reindex();
+  const repeatVault = new Vault(repeatRoot);
+  await repeatVault.reindex();
+  const singleRanks = computePageRank(singleVault);
+  const repeatRanks = computePageRank(repeatVault);
+  const singleTargetScore = singleRanks.get("target") ?? 0;
+  const repeatTargetScore = repeatRanks.get("target") ?? 0;
+  assert(
+    Math.abs(singleTargetScore - repeatTargetScore) < 1e-9,
+    `repeated wiki-links deduped: single=${singleTargetScore.toFixed(9)} repeat=${repeatTargetScore.toFixed(9)}`
+  );
+  fs.rmSync(singleRoot, { recursive: true, force: true });
+  fs.rmSync(repeatRoot, { recursive: true, force: true });
 
   process.stderr.write("\nempty-edge vault: no links → no throw, zero-ish scores\n");
   const emptyRoot = path.join(os.tmpdir(), `vault-empty-${process.pid}`);
@@ -327,7 +365,7 @@ status: current
   assert(envelope.results.length < bigItems.length, "envelope dropped lower-ranked items");
   assert(envelope.results.length >= 1, "envelope keeps at least top item");
 
-  process.stderr.write("\noutline truncation: marker appears when over budget\n");
+  process.stderr.write("\nfitOutlineBlocks: truncation marker appears when over budget\n");
   // Synthesize blocks like the mcp tool would produce.
   const fatBlocks = [];
   for (let i = 0; i < 8; i++) {
@@ -335,32 +373,23 @@ status: current
       `# Note ${i} (demo/note-${i})\n## Heading ${i} A\n## Heading ${i} B\n## Heading ${i} C`
     );
   }
-  // Emulate fitOutlineBlocks with a tight budget.
-  const fit = (blocks, budget) => {
-    let text = "";
-    let included = 0;
-    for (const block of blocks) {
-      const next = included === 0 ? block : text + "\n\n" + block;
-      if (next.length > budget && included > 0) break;
-      text = next;
-      included += 1;
-    }
-    const omitted = blocks.length - included;
-    if (omitted > 0) {
-      const suffix = omitted === 1 ? "" : "s";
-      text += `\n\n[truncated: ${omitted} note${suffix} omitted]`;
-    }
-    return text;
-  };
-  const tight = fit(fatBlocks, 200);
-  assert(/\[truncated: \d+ notes? omitted\]/.test(tight), "truncation marker present");
-  assert(tight.includes("# Note 0 (demo/note-0)"), "first note preserved even with tight budget");
+  const tight = fitOutlineBlocks(fatBlocks, 200);
+  assert(/\[truncated: \d+ notes? omitted\]/.test(tight.text), "truncation marker present");
+  assert(tight.text.includes("# Note 0 (demo/note-0)"), "first note preserved even with tight budget");
+  assert(tight.omitted > 0, "fitOutlineBlocks reports omitted > 0");
+  assert(tight.included + tight.omitted === fatBlocks.length, "included + omitted = total blocks");
 
-  process.stderr.write("\noutline: single oversize block still returned (at-least-one contract)\n");
+  process.stderr.write("\nfitOutlineBlocks: single oversize block still returned (at-least-one contract)\n");
   const huge = "# Huge (demo/huge)\n" + "## Section\n".repeat(500);
-  const fitHuge = fit([huge], 100);
-  assert(fitHuge.startsWith("# Huge"), "single oversize block is returned unsliced");
-  assert(!/\[truncated:/.test(fitHuge), "no truncation marker when only one block and nothing omitted");
+  const fitHuge = fitOutlineBlocks([huge], 100);
+  assert(fitHuge.text.startsWith("# Huge"), "single oversize block is returned unsliced");
+  assert(!/\[truncated:/.test(fitHuge.text), "no truncation marker when only one block and nothing omitted");
+  assert(fitHuge.omitted === 0 && fitHuge.included === 1, "fitOutlineBlocks counts single block correctly");
+
+  process.stderr.write("\nfitOutlineBlocks: empty input returns empty\n");
+  const emptyFit = fitOutlineBlocks([], 1000);
+  assert(emptyFit.text === "", "empty blocks list → empty text");
+  assert(emptyFit.included === 0 && emptyFit.omitted === 0, "empty blocks list → zero counts");
 
   teardown();
   if (failed > 0) {

--- a/test/tour-outline.test.js
+++ b/test/tour-outline.test.js
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+/**
+ * vault_tour + vault_outline assertions — issue #29.
+ *
+ * Exercises:
+ *   - computePageRank: monotonicity (hub > leaf), empty vault, deprecated skip,
+ *     stale downweight, project prefix filter semantics.
+ *   - extractOutline: maxDepth, code-fence skipping (``` and ~~~), frontmatter.
+ *   - tour envelope respects maxChars (applyCharBudget integration).
+ *   - outline truncation marker appears when blocks exceed maxChars.
+ */
+import fs from "fs";
+import fsp from "fs/promises";
+import os from "os";
+import path from "path";
+import { Vault } from "../lib/vault.js";
+import { computePageRank } from "../lib/graph.js";
+import { extractOutline } from "../lib/outline.js";
+import { applyCharBudget } from "../lib/budgets.js";
+
+const ROOT = path.join(os.tmpdir(), `vault-tour-outline-${process.pid}`);
+
+function reset() {
+  if (fs.existsSync(ROOT)) fs.rmSync(ROOT, { recursive: true, force: true });
+  fs.mkdirSync(ROOT, { recursive: true });
+}
+function teardown() {
+  try {
+    fs.rmSync(ROOT, { recursive: true, force: true });
+  } catch {}
+}
+
+let failed = 0;
+function assert(cond, msg) {
+  if (cond) process.stderr.write(`  ✓ ${msg}\n`);
+  else {
+    failed++;
+    process.stderr.write(`  ✗ ${msg}\n`);
+  }
+}
+
+async function writeNote(relPath, content) {
+  const full = path.join(ROOT, relPath);
+  await fsp.mkdir(path.dirname(full), { recursive: true });
+  await fsp.writeFile(full, content, "utf-8");
+}
+
+async function makeVault() {
+  const v = new Vault(ROOT);
+  await v.reindex();
+  return v;
+}
+
+async function main() {
+  reset();
+
+  process.stderr.write("computePageRank: hub > leaf monotonicity\n");
+  await writeNote(
+    "demo/VAULT_SUMMARY.md",
+    `---
+id: demo/vault-summary
+title: Demo Vault Summary
+type: overview
+status: current
+---
+
+# Demo
+
+See [[demo/hub]] for architecture.
+`
+  );
+  await writeNote(
+    "demo/hub.md",
+    `---
+id: demo/hub
+title: Architecture Hub
+type: architecture
+status: current
+---
+
+# Architecture Hub
+
+Shared by many notes.
+
+## Context
+
+Used across the stack.
+`
+  );
+  await writeNote(
+    "demo/a.md",
+    `---
+id: demo/a
+title: Leaf A
+type: feature
+status: current
+---
+
+# Leaf A
+
+See [[demo/hub]].
+`
+  );
+  await writeNote(
+    "demo/b.md",
+    `---
+id: demo/b
+title: Leaf B
+type: feature
+status: current
+---
+
+# Leaf B
+
+See [[demo/hub]].
+`
+  );
+  await writeNote(
+    "demo/c.md",
+    `---
+id: demo/c
+title: Leaf C
+type: feature
+status: current
+---
+
+# Leaf C
+
+See [[demo/hub]] and [[demo/a]].
+`
+  );
+  await writeNote(
+    "demo/orphan.md",
+    `---
+id: demo/orphan
+title: Lonely Leaf
+type: feature
+status: current
+---
+
+# Lonely Leaf
+
+No links.
+`
+  );
+
+  let vault = await makeVault();
+  let ranks = computePageRank(vault);
+  assert(ranks.size === vault.index.length, "ranks cover every active note");
+  const hubScore = ranks.get("demo/hub") ?? 0;
+  const leafScore = ranks.get("demo/orphan") ?? 0;
+  assert(hubScore > leafScore, `hub (${hubScore.toFixed(5)}) > orphan (${leafScore.toFixed(5)})`);
+  const leafAScore = ranks.get("demo/a") ?? 0;
+  assert(hubScore > leafAScore, `hub (${hubScore.toFixed(5)}) > leaf a (${leafAScore.toFixed(5)})`);
+
+  process.stderr.write("\ncomputePageRank: empty vault is graceful\n");
+  const emptyRanks = computePageRank({ index: [] });
+  assert(emptyRanks instanceof Map, "empty vault returns a Map");
+  assert(emptyRanks.size === 0, "empty vault returns empty scores");
+
+  process.stderr.write("\ncomputePageRank: undefined vault guard\n");
+  const guard1 = computePageRank(null);
+  const guard2 = computePageRank(undefined);
+  assert(guard1.size === 0, "null vault returns empty Map");
+  assert(guard2.size === 0, "undefined vault returns empty Map");
+
+  process.stderr.write("\ncomputePageRank: deprecated notes excluded\n");
+  await writeNote(
+    "demo/deprecated-note.md",
+    `---
+id: demo/deprecated-note
+title: Gone
+type: feature
+status: deprecated
+---
+
+# Gone
+`
+  );
+  vault = await makeVault();
+  ranks = computePageRank(vault);
+  assert(!ranks.has("demo/deprecated-note"), "deprecated note absent from scores");
+
+  process.stderr.write("\ncomputePageRank: stale downweight\n");
+  await writeNote(
+    "demo/stale-note.md",
+    `---
+id: demo/stale-note
+title: Stale
+type: feature
+status: stale
+---
+
+# Stale
+
+See [[demo/hub]].
+`
+  );
+  await writeNote(
+    "demo/current-note.md",
+    `---
+id: demo/current-note
+title: Current
+type: feature
+status: current
+---
+
+# Current
+
+See [[demo/hub]].
+`
+  );
+  vault = await makeVault();
+  ranks = computePageRank(vault);
+  const staleScore = ranks.get("demo/stale-note") ?? 0;
+  const currentScore = ranks.get("demo/current-note") ?? 0;
+  assert(
+    staleScore < currentScore,
+    `stale (${staleScore.toFixed(6)}) penalized vs current (${currentScore.toFixed(6)})`
+  );
+
+  process.stderr.write("\nproject id-prefix filter semantics\n");
+  await writeNote(
+    "other-proj/note.md",
+    `---
+id: other-proj/note
+title: Other Project Note
+type: feature
+status: current
+---
+
+# Other
+`
+  );
+  vault = await makeVault();
+  // Emulate the mcp filter: prefix = project + "/"; match id === project OR startsWith prefix.
+  const filterByProject = (noteId, project) => {
+    const prefix = project.endsWith("/") ? project : project + "/";
+    return noteId === project || noteId.startsWith(prefix);
+  };
+  const demoMatches = vault.index
+    .filter((n) => filterByProject(n.id, "demo"))
+    .map((n) => n.id);
+  assert(
+    demoMatches.every((id) => id.startsWith("demo/")),
+    "project=demo matches only demo/* ids"
+  );
+  const otherMatches = vault.index
+    .filter((n) => filterByProject(n.id, "other-proj"))
+    .map((n) => n.id);
+  assert(
+    otherMatches.length === 1 && otherMatches[0] === "other-proj/note",
+    "project=other-proj matches single note"
+  );
+  // No project = no filter: returns all.
+  assert(vault.index.length >= 7, "vault has many notes overall (no filter)");
+
+  process.stderr.write("\nempty-edge vault: no links → no throw, zero-ish scores\n");
+  const emptyRoot = path.join(os.tmpdir(), `vault-empty-${process.pid}`);
+  if (fs.existsSync(emptyRoot)) fs.rmSync(emptyRoot, { recursive: true, force: true });
+  fs.mkdirSync(emptyRoot, { recursive: true });
+  await fsp.writeFile(
+    path.join(emptyRoot, "solo.md"),
+    `---\nid: solo\ntitle: Solo\ntype: feature\nstatus: current\n---\n\n# Solo\n\nNo links.\n`,
+    "utf-8"
+  );
+  const soloVault = new Vault(emptyRoot);
+  await soloVault.reindex();
+  const soloRanks = computePageRank(soloVault);
+  assert(soloRanks.size === 1, "single-note vault returns one rank");
+  assert((soloRanks.get("solo") ?? 0) > 0, "single-note rank is positive");
+  fs.rmSync(emptyRoot, { recursive: true, force: true });
+
+  process.stderr.write("\nextractOutline: maxDepth respected (maxDepth:2 suppresses H3)\n");
+  const md1 = `# Title\n\n## Section A\n\ntext\n\n### Sub A1\n\ntext\n\n## Section B\n\n### Sub B1\n`;
+  const depth2 = extractOutline(md1, 2);
+  const levels2 = depth2.map((h) => h.level);
+  assert(
+    levels2.every((lvl) => lvl <= 2),
+    `no H3 at maxDepth 2 (got levels ${levels2.join(",")})`
+  );
+  const depth3 = extractOutline(md1, 3);
+  assert(
+    depth3.some((h) => h.level === 3),
+    "H3 included at maxDepth 3"
+  );
+
+  process.stderr.write("\nextractOutline: backtick fences skipped\n");
+  const md2 = `# Title\n\n## Real\n\n\`\`\`\n## Fake heading in code fence\n\`\`\`\n\n## Also real\n`;
+  const out2 = extractOutline(md2, 2).map((h) => h.text);
+  assert(
+    out2.includes("Real") && out2.includes("Also real") && !out2.includes("Fake heading in code fence"),
+    "backtick-fenced heading excluded"
+  );
+
+  process.stderr.write("\nextractOutline: tilde fences skipped\n");
+  const md3 = `# Title\n\n~~~\n## Not a real heading\n~~~\n\n## Only heading\n`;
+  const out3 = extractOutline(md3, 2).map((h) => h.text);
+  assert(
+    out3.length === 2 && out3.includes("Only heading") && !out3.includes("Not a real heading"),
+    "tilde-fenced heading excluded"
+  );
+
+  process.stderr.write("\nextractOutline: frontmatter ignored\n");
+  const md4 = `---\ntitle: Foo\nsummary: "# looks like heading"\n---\n\n# Actual Title\n\n## A\n`;
+  const out4 = extractOutline(md4, 2).map((h) => h.text);
+  assert(
+    out4.length === 2 && out4[0] === "Actual Title" && out4[1] === "A",
+    "frontmatter stripped before scan"
+  );
+
+  process.stderr.write("\nextractOutline: empty input\n");
+  assert(extractOutline("", 2).length === 0, "empty string → []");
+  assert(extractOutline(null, 2).length === 0, "null input → []");
+
+  process.stderr.write("\napplyCharBudget: tour envelope truncates to fit maxChars\n");
+  const bigItems = Array.from({ length: 20 }, (_, i) => ({
+    id: `demo/note-${i}`,
+    title: `Note ${i} with a reasonably long padded title so JSON bytes grow`,
+    summary: "x".repeat(200),
+    type: "feature",
+    pageRank: 0.01 - i * 0.0001,
+    status: "current",
+  }));
+  const envelope = applyCharBudget(bigItems, 800);
+  assert(envelope.truncated === true, "envelope.truncated flagged");
+  assert(envelope.results.length < bigItems.length, "envelope dropped lower-ranked items");
+  assert(envelope.results.length >= 1, "envelope keeps at least top item");
+
+  process.stderr.write("\noutline truncation: marker appears when over budget\n");
+  // Synthesize blocks like the mcp tool would produce.
+  const fatBlocks = [];
+  for (let i = 0; i < 8; i++) {
+    fatBlocks.push(
+      `# Note ${i} (demo/note-${i})\n## Heading ${i} A\n## Heading ${i} B\n## Heading ${i} C`
+    );
+  }
+  // Emulate fitOutlineBlocks with a tight budget.
+  const fit = (blocks, budget) => {
+    let text = "";
+    let included = 0;
+    for (const block of blocks) {
+      const next = included === 0 ? block : text + "\n\n" + block;
+      if (next.length > budget && included > 0) break;
+      text = next;
+      included += 1;
+    }
+    const omitted = blocks.length - included;
+    if (omitted > 0) {
+      const suffix = omitted === 1 ? "" : "s";
+      text += `\n\n[truncated: ${omitted} note${suffix} omitted]`;
+    }
+    return text;
+  };
+  const tight = fit(fatBlocks, 200);
+  assert(/\[truncated: \d+ notes? omitted\]/.test(tight), "truncation marker present");
+  assert(tight.includes("# Note 0 (demo/note-0)"), "first note preserved even with tight budget");
+
+  process.stderr.write("\noutline: single oversize block still returned (at-least-one contract)\n");
+  const huge = "# Huge (demo/huge)\n" + "## Section\n".repeat(500);
+  const fitHuge = fit([huge], 100);
+  assert(fitHuge.startsWith("# Huge"), "single oversize block is returned unsliced");
+  assert(!/\[truncated:/.test(fitHuge), "no truncation marker when only one block and nothing omitted");
+
+  teardown();
+  if (failed > 0) {
+    process.stderr.write(`\n${failed} assertion(s) failed\n`);
+    process.exit(1);
+  }
+  process.stderr.write("\nall tour+outline assertions passed\n");
+}
+
+main().catch((e) => {
+  process.stderr.write(`test error: ${e.stack || e.message}\n`);
+  teardown();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- `vault_tour({ project?, limit?, maxChars? })` — ranked orientation: top-N notes by graph centrality (PageRank blended 70/30 with inbound-degree). Seeded on `VAULT_SUMMARY` / `overview`; deprecated excluded, stale 0.7×. Standard `{ results, truncated }` envelope.
- `vault_outline({ project?, maxDepth?, maxChars? })` — plain-text TOC (`# title (id)` + indented H2/H3 per note). No JSON parsing required. Headings inside ``` and ~~~ fences skipped. Truncation marker `[truncated: N notes omitted]` at whole-note boundaries.

## Design notes
- **PageRank blending (70/30)** — pure PageRank on a small/thin vault over-weights the seed; adding normalized inbound-degree lets real content hubs surface. On the demo vault the top 3 are `embeddings-pipeline`, `gotchas`, `semantic-search` — matches intuition.
- **Plain-text outline** — issue spec says "no JSON parsing required"; we return a single `text/plain` content item with indented markdown. Makes the output directly skimmable by a reasoning loop.
- **Cache** — `pageRankScores` is rebuilt on reindex and post-write, mirroring the glossary pattern in `lib/mcp.js`. Computation is O(iters × edges), trivial at typical vault sizes.
- **project filter** — id-prefix semantics (`project === id || id.startsWith(project + "/")`), consistent with `folder` on `vault_semantic_search`.
- **Seeded teleport** — `VAULT_SUMMARY*` / `overview*` ids get a 3× teleport bias so new sessions land on orientation; damping 0.85 keeps the rest of the graph honest.
- **Code-fence safety** — outline extractor tracks both ``` and ~~~ fences, matching the pattern already in `lib/vault.js._extractBacklinks` and `lib/glossary.js`.

## Files touched
- `lib/graph.js` — add `computePageRank(vault)` pure helper (no deps).
- `lib/outline.js` (new) — pure `extractOutline(markdown, maxDepth)`.
- `lib/mcp.js` — register `vault_tour` + `vault_outline`; rebuild PageRank cache on reindex and post-write.
- `test/tour-outline.test.js` (new) — 29 assertions.
- `.github/workflows/ci.yml` — typecheck + dedicated CI step for the new suite.

## Test plan
- [x] `npx tsc --noEmit --allowJs --skipLibCheck` clean across all JS
- [x] `node test/tour-outline.test.js` — all 29 assertions pass
- [x] `node test/retrieval/eval.js --gate 2 --warn-gate 0.5` — no regression
- [x] Every other suite (retrieval status, vault-write, section-edit, stubs, query-log, glossary, budgets) passes
- [x] `node index.js lint --vault vault --format github` — 0 errors, 2 pre-existing warnings
- [x] Hand-invoked `vault_tour` + `vault_outline` via an MCP client against the real demo vault; outputs sensible, truncation marker present under a tight budget

## Invariants honored
- `VAULT_DIR` env-var respected; no hardcoded paths
- Additive, backward-compatible MCP surface
- No new runtime deps; PageRank + outline are plain JS
- `package.json` `files` already excludes `vault/` and `test/`
- Commit authored under `bernardoagbranco@gmail.com`

Closes #29