### PR TITLE
feat(mcp): route agents vault-first via tool descriptions

### DIFF
--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -114,7 +114,7 @@ server.registerTool(
   "vault_search",
   {
     description:
-      "Search vault notes by keyword. Matches against note title, tags, id, and body — title/tag/id hits are weighted higher so metadata matches still outrank body-only matches. Multi-word queries award extra points per token found in the body, so all-terms-present notes rank above partial matches. Returns notes ranked by relevance. Status-aware: notes with `status: deprecated` are excluded by default; `status: stale` is downranked. Pass `includeDeprecated: true` to include deprecated notes; pass `staleWeight` (0..1, default 0.7) to tune the stale penalty. Response shape: `{ results, truncated }` — results are the ranked note summaries; `truncated: true` indicates lower-ranked results were dropped to fit the `maxChars` budget (default 8000 ≈ 2000 tokens). The top-ranked result is always returned even if it alone exceeds the budget.",
+      "REACH FOR THIS BEFORE Grep when you know a specific term (function name, env var, file name, error string). The vault indexes project docs, ADRs, runbooks, and gotchas — answers to 'what is X?' / 'where is X documented?' live here, not in the source tree. Matches against note title, tags, id, and body; title/tag/id hits are weighted higher so metadata matches still outrank body-only matches. Multi-word queries award extra points per token found in the body. Returns notes ranked by relevance. Status-aware: `status: deprecated` excluded by default, `status: stale` downranked. Pass `includeDeprecated: true` to include deprecated; `staleWeight` (0..1, default 0.7) tunes the stale penalty. Response shape: `{ results, truncated }`; `truncated: true` means lower-ranked results were dropped to fit `maxChars` (default 8000 ≈ 2000 tokens). Top result always returned. If this returns nothing for a term you expected to find, that's the signal the vault has a gap — consider `vault_create_note` after you finish the task.",
     inputSchema: {
       query: z.string(),
       limit: z.number().int().positive().optional(),
@@ -156,7 +156,7 @@ server.registerTool(
   "vault_read",
   {
     description:
-      "Read a single vault note by id (e.g. 'claude-code-vault/overview'). Returns full raw markdown plus forward links and backlinks. `resolvedTerms` is always present: when `resolveJargon` is true (default), it lists bare mentions of terms defined in any `type: glossary` note — each with `{ term, definition, source, sectionHeading }` — capped at 20 entries per read. When `resolveJargon: false`, it is an empty array. Mentions inside code fences/spans, `[[wiki-links]]`, and frontmatter are ignored; the note's own glossary terms (if it is itself a glossary) are never resolved back to itself.",
+      "REACH FOR THIS BEFORE opening source files with Read when a vault_search / vault_semantic_search result points to a note id. Reads a single vault note by id (e.g. 'claude-code-vault/overview'). Returns full raw markdown plus forward links and backlinks. `resolvedTerms` is always present: when `resolveJargon` is true (default), it lists bare mentions of terms defined in any `type: glossary` note — each with `{ term, definition, source, sectionHeading }` — capped at 20 entries per read. When `resolveJargon: false`, it is an empty array. Mentions inside code fences/spans, `[[wiki-links]]`, and frontmatter are ignored; the note's own glossary terms (if it is itself a glossary) are never resolved back to itself.",
     inputSchema: {
       id: z.string(),
       resolveJargon: z.boolean().optional().default(true),
@@ -196,7 +196,7 @@ server.registerTool(
   "vault_list",
   {
     description:
-      "List all vault notes, optionally filtered by a tag. Returns id, title, tags, and word count for each. Response shape: `{ results, truncated }`. Results are trimmed from the bottom to fit `maxChars` (default 8000 ≈ 2000 tokens); `truncated: true` means more notes exist but were dropped. Use a larger `maxChars` to paginate by byte budget.",
+      "REACH FOR THIS BEFORE Glob / `ls` when you want to discover what the vault covers. Lists all vault notes, optionally filtered by a tag. Returns id, title, tags, and word count for each. Response shape: `{ results, truncated }`. Results are trimmed from the bottom to fit `maxChars` (default 8000 ≈ 2000 tokens); `truncated: true` means more notes exist but were dropped. Use a larger `maxChars` to paginate by byte budget.",
     inputSchema: {
       tag: z.string().optional(),
       maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
@@ -224,7 +224,7 @@ server.registerTool(
   "vault_lint",
   {
     description:
-      "Lint the vault for content-quality issues: dead wiki-links, missing frontmatter (title/type/tags/description), orphan notes, heading hierarchy skips, oversize/undersize notes, duplicate-candidate pairs (Jaccard on tokens), stale lastVerified dates, stale stubs (draft notes with tags: [stub] older than staleStubDays), and unknown enum values for status/type. Returns findings as a JSON array — each finding has { level: 'error'|'warning'|'info', code, message, noteId, file, line }. Codes are stable (e.g. 'dead-link', 'stale-stub'). Call this to check vault health before authoring new notes, or after large refactors.",
+      "CALL THIS BEFORE committing a new note or after a batch-edit to catch content-quality issues. Lints the vault for: dead wiki-links, missing frontmatter (title/type/tags/description), orphan notes, heading hierarchy skips, oversize/undersize notes, duplicate-candidate pairs (Jaccard on tokens), stale lastVerified dates, stale stubs (draft notes with tags: [stub] older than staleStubDays), and unknown enum values for status/type. Returns findings as a JSON array — each finding has { level: 'error'|'warning'|'info', code, message, noteId, file, line }. Codes are stable (e.g. 'dead-link', 'stale-stub'). Call this to check vault health before authoring new notes, or after large refactors.",
     inputSchema: {
       staleDays: z.number().int().positive().optional(),
       staleStubDays: z.number().int().positive().optional(),
@@ -242,7 +242,7 @@ server.registerTool(
   "vault_related",
   {
     description:
-      "Get the 1-hop graph neighbors for a note: forward links (notes it links to) and backlinks (notes that link to it).",
+      "Get the 1-hop graph neighbors for a note: forward links and backlinks. Use this after vault_read to decide which neighbor to pull next; prefer vault_read_with_context if you know you'll want neighbor bodies in the same call.",
     inputSchema: { id: z.string() },
   },
   safe(async ({ id }) => {
@@ -268,7 +268,7 @@ if (embeddingsDb) {
     "vault_semantic_search",
     {
       description:
-        "Search vault notes by meaning, not exact keywords. Returns notes ranked by cosine similarity of their best-matching chunk to the query, along with the heading path of that best chunk. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: deprecated notes are excluded and stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use when looking for notes *about* a concept (e.g. 'notes about authentication'). Pair with vault_read when you need the full note, or vault_search_chunks when you only need the most relevant paragraphs. Response shape: `{ results, truncated }` — lower-ranked matches are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top match is always returned.",
+        "REACH FOR THIS FIRST — before Grep, before Read, before spawning a subagent — on any question-shaped task ('why does X happen?', 'how do we handle Y?', 'what's the approach for Z?'). The vault is this project's institutional memory: ADRs, design docs, runbooks, gotchas, past incidents. A single call here usually replaces 5+ Grep/Read round-trips and protects the main context window. If this returns nothing relevant, THEN fall back to filesystem search. Also call this on the task statement itself before spawning any Explore / general-purpose subagent, and pass the top 2-3 hits into the subagent's prompt as ground truth — subagents start cold and will otherwise re-derive what's already documented. Searches vault notes by meaning, not exact keywords. Returns notes ranked by cosine similarity of their best-matching chunk to the query, along with the heading path of that best chunk. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: deprecated notes are excluded and stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use when looking for notes *about* a concept (e.g. 'notes about authentication'). Pair with vault_read when you need the full note, or vault_search_chunks when you only need the most relevant paragraphs. Response shape: `{ results, truncated }` — lower-ranked matches are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top match is always returned.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
@@ -323,7 +323,7 @@ if (embeddingsDb) {
     "vault_search_chunks",
     {
       description:
-        "Search vault at the paragraph/section level. Returns the most semantically similar chunks (not whole notes), each with its heading breadcrumb (e.g. 'ADR-001 > Rationale > Why Workers'), the chunk text itself, any wiki-links it contains, and a similarity score. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: chunks from deprecated notes are excluded and chunks from stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use this when you want just the relevant passage — much cheaper than reading whole notes. Follow up with vault_read if the surrounding file context matters. Response shape: `{ results, truncated }` — lower-ranked chunks are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top chunk is always returned even if its text alone exceeds the budget.",
+        "REACH FOR THIS BEFORE Grep with context flags (-A/-B/-C) when you want one specific passage, not a whole note. Searches vault at the paragraph/section level. Returns the most semantically similar chunks (not whole notes), each with its heading breadcrumb (e.g. 'ADR-001 > Rationale > Why Workers'), the chunk text itself, any wiki-links it contains, and a similarity score. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: chunks from deprecated notes are excluded and chunks from stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use this when you want just the relevant passage — much cheaper than reading whole notes. Follow up with vault_read if the surrounding file context matters. Response shape: `{ results, truncated }` — lower-ranked chunks are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top chunk is always returned even if its text alone exceeds the budget.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
@@ -378,7 +378,7 @@ if (embeddingsDb) {
     "vault_read_with_context",
     {
       description:
-        "Read a note AND its graph neighbors (notes it links to + notes that link to it) in one call. Each neighbor comes with its relation (forward/backlink/bidirectional), an edge weight (how many chunks reference it), and an intro snippet. Use this instead of vault_read when you want the surrounding context — saves round-trips. Bounded by maxChars (default 8000); `truncated: true` in the response means some snippets were trimmed or neighbors dropped.",
+        "REACH FOR THIS INSTEAD OF vault_read when you're likely to need the surrounding docs — saves multi-call fan-out. Reads a note AND its graph neighbors (notes it links to + notes that link to it) in one call. Each neighbor comes with its relation (forward/backlink/bidirectional), an edge weight (how many chunks reference it), and an intro snippet. Use this instead of vault_read when you want the surrounding context — saves round-trips. Bounded by maxChars (default 8000); `truncated: true` in the response means some snippets were trimmed or neighbors dropped.",
       inputSchema: {
         id: z.string(),
         depth: z.number().int().min(1).max(2).optional(),
@@ -432,7 +432,7 @@ if (embeddingsDb) {
     "vault_search_chunks_with_context",
     {
       description:
-        "Like vault_search_chunks but also returns graph neighbors of the notes whose chunks were hit. For each chunk result you get the usual (text, heading breadcrumb, links, similarity); additionally a `neighbors` array lists notes linked from those chunks, ranked by edge weight (bidirectional first, then link frequency, then recency). Supports the same pre-filters as vault_search_chunks (`folder`, `tag`, `after`, `before`) — filters are applied to the chunk search stage, not to neighbor expansion. Status-aware: chunks from deprecated notes are excluded and chunks from stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use when a query needs both the passage and the surrounding graph context. maxChars caps total neighbor-snippet bytes.",
+        "REACH FOR THIS INSTEAD OF vault_search_chunks when the answer likely spans a note and its neighbors. Like vault_search_chunks but also returns graph neighbors of the notes whose chunks were hit. For each chunk result you get the usual (text, heading breadcrumb, links, similarity); additionally a `neighbors` array lists notes linked from those chunks, ranked by edge weight (bidirectional first, then link frequency, then recency). Supports the same pre-filters as vault_search_chunks (`folder`, `tag`, `after`, `before`) — filters are applied to the chunk search stage, not to neighbor expansion. Status-aware: chunks from deprecated notes are excluded and chunks from stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use when a query needs both the passage and the surrounding graph context. maxChars caps total neighbor-snippet bytes.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
@@ -525,7 +525,7 @@ server.registerTool(
   "vault_tour",
   {
     description:
-      "Return the top-`limit` most important notes in the vault, ranked by graph centrality (PageRank, damping 0.85, blended 70/30 with inbound-degree). Use at the start of a new session to orient an agent in the vault without walking links manually. Deprecated notes are excluded; stale notes are downweighted (0.7×). VAULT_SUMMARY / overview notes get a seed bias so new sessions land on orientation first. `folder` is an optional id-prefix filter (e.g. 'claude-code-vault' — matches any note whose id begins with that prefix, consistent with `folder` on vault_semantic_search). Response shape: `{ results, truncated }`. Each result: `{ id, title, summary, type, pageRank, status }`. Default `limit` 10 (max 200). Bounded by `maxChars` (default 8000 ≈ 2000 tokens).",
+      "REACH FOR THIS AT SESSION START BEFORE exploring directories with Glob/ls — it's the fastest way to orient in an unfamiliar vault. Returns the top-`limit` most important notes in the vault, ranked by graph centrality (PageRank, damping 0.85, blended 70/30 with inbound-degree). Use at the start of a new session to orient an agent in the vault without walking links manually. Deprecated notes are excluded; stale notes are downweighted (0.7×). VAULT_SUMMARY / overview notes get a seed bias so new sessions land on orientation first. `folder` is an optional id-prefix filter (e.g. 'claude-code-vault' — matches any note whose id begins with that prefix, consistent with `folder` on vault_semantic_search). Response shape: `{ results, truncated }`. Each result: `{ id, title, summary, type, pageRank, status }`. Default `limit` 10 (max 200). Bounded by `maxChars` (default 8000 ≈ 2000 tokens).",
     inputSchema: {
       folder: z.string().min(1).optional(),
       limit: z.number().int().positive().max(200).optional(),
@@ -559,7 +559,7 @@ server.registerTool(
   "vault_outline",
   {
     description:
-      "Return a plain-text table of contents for the vault — each note's title + top `maxDepth` heading levels. Cheap, skimmable, no JSON parsing required. Use to understand the shape of a folder without reading full notes. Structure per note: a `# title (id)` line followed by indented `##`/`###` headings. Deprecated notes are excluded. `folder` is an optional id-prefix filter (consistent with `folder` on vault_semantic_search). Default `maxDepth` 2 (H2 only below the title line). Headings inside fenced code blocks are skipped. Response shape: `{ outline, truncated, noteCount }` — `outline` is the packed markdown text; if it exceeds `maxChars` (default 8000) it is cut at a whole-note boundary with a trailing `[truncated: N notes omitted]` marker and `truncated` is `true`.",
+      "REACH FOR THIS INSTEAD OF reading multiple notes to understand a folder — skimmable TOC of titles + headings, no JSON parsing. Returns a plain-text table of contents for the vault — each note's title + top `maxDepth` heading levels. Cheap, skimmable, no JSON parsing required. Use to understand the shape of a folder without reading full notes. Structure per note: a `# title (id)` line followed by indented `##`/`###` headings. Deprecated notes are excluded. `folder` is an optional id-prefix filter (consistent with `folder` on vault_semantic_search). Default `maxDepth` 2 (H2 only below the title line). Headings inside fenced code blocks are skipped. Response shape: `{ outline, truncated, noteCount }` — `outline` is the packed markdown text; if it exceeds `maxChars` (default 8000) it is cut at a whole-note boundary with a trailing `[truncated: N notes omitted]` marker and `truncated` is `true`.",
     inputSchema: {
       folder: z.string().min(1).optional(),
       maxDepth: z.number().int().min(1).max(6).optional(),
@@ -613,7 +613,7 @@ server.registerTool(
   "vault_create_note",
   {
     description:
-      "Create a new vault note. Fails if the id already exists or required fields are missing. Unresolved `[[target]]` wiki-links in the body auto-create draft stub notes (tags: [stub]) pointing back at this note, so authoring never blocks on chain-of-reference; the `createdStubs` field reports which ids were stubbed. Bare mentions of existing note titles or glossary terms come back as `suggestedLinks` (not auto-inserted — the agent decides). Frontmatter is built from the provided fields; `date` and `lastVerified` default to today. After writing, the vault is reindexed and embeddings are synced. Returns `{ note, createdStubs, suggestedLinks }`.",
+      "CALL THIS AFTER a task where vault_search / vault_semantic_search came up empty on something you ended up learning — closes the knowledge loop so the next agent lands on the note instead of re-deriving it. Creates a new vault note. Fails if the id already exists or required fields are missing. Unresolved `[[target]]` wiki-links in the body auto-create draft stub notes (tags: [stub]) pointing back at this note, so authoring never blocks on chain-of-reference; the `createdStubs` field reports which ids were stubbed. Bare mentions of existing note titles or glossary terms come back as `suggestedLinks` (not auto-inserted — the agent decides). Frontmatter is built from the provided fields; `date` and `lastVerified` default to today. After writing, the vault is reindexed and embeddings are synced. Returns `{ note, createdStubs, suggestedLinks }`.",
     inputSchema: {
       id: z.string(),
       type: z.string(),
@@ -648,7 +648,7 @@ server.registerTool(
   "vault_write",
   {
     description:
-      "Update an existing vault note. `content` may be either (a) full markdown with a leading `---` frontmatter block — frontmatter is merge-patched over the existing file's frontmatter (new keys win, untouched keys preserved) and body is replaced; or (b) body-only markdown (no leading frontmatter) — existing frontmatter is preserved verbatim and only the body is replaced. Fails if the note does not exist (use vault_create_note) or if the body is empty. Unresolved `[[target]]` wiki-links auto-stub (see vault_create_note). `suggestedLinks` returns bare mentions of known titles/terms. Returns `{ note, createdStubs, suggestedLinks }`.",
+      "PREFER vault_append_section / vault_replace_section for targeted edits — use this only for full-note rewrites. Updates an existing vault note. `content` may be either (a) full markdown with a leading `---` frontmatter block — frontmatter is merge-patched over the existing file's frontmatter (new keys win, untouched keys preserved) and body is replaced; or (b) body-only markdown (no leading frontmatter) — existing frontmatter is preserved verbatim and only the body is replaced. Fails if the note does not exist (use vault_create_note) or if the body is empty. Unresolved `[[target]]` wiki-links auto-stub (see vault_create_note). `suggestedLinks` returns bare mentions of known titles/terms. Returns `{ note, createdStubs, suggestedLinks }`.",
     inputSchema: {
       id: z.string(),
       content: z.string(),
@@ -677,7 +677,7 @@ server.registerTool(
   "vault_append_section",
   {
     description:
-      "Append `content` to a single heading-section of an existing note, identified by `headingPath` — a strict ancestor chain of heading texts (e.g. `[\"Gotchas\", \"Auth retry storm\"]` for an H2 \"Auth retry storm\" nested directly under H1 \"Gotchas\"). The new content lands after the section's last non-blank body line, before the next same-or-higher heading. The heading line itself is never modified, frontmatter is left untouched. Fails if the path matches zero or multiple sections. Unresolved `[[target]]` wiki-links auto-stub (see vault_create_note); `suggestedLinks` returns bare mentions of known titles/terms. Returns `{ note, createdStubs, suggestedLinks }`.",
+      "PREFER THIS OVER vault_write when adding to an existing section — surgical edit, no risk of clobbering the rest of the note. Appends `content` to a single heading-section of an existing note, identified by `headingPath` — a strict ancestor chain of heading texts (e.g. `[\"Gotchas\", \"Auth retry storm\"]` for an H2 \"Auth retry storm\" nested directly under H1 \"Gotchas\"). The new content lands after the section's last non-blank body line, before the next same-or-higher heading. The heading line itself is never modified, frontmatter is left untouched. Fails if the path matches zero or multiple sections. Unresolved `[[target]]` wiki-links auto-stub (see vault_create_note); `suggestedLinks` returns bare mentions of known titles/terms. Returns `{ note, createdStubs, suggestedLinks }`.",
     inputSchema: {
       id: z.string(),
       headingPath: z.array(z.string()).min(1),
@@ -707,7 +707,7 @@ server.registerTool(
   "vault_replace_section",
   {
     description:
-      "Replace the body of a single heading-section. `headingPath` selects the section under strict-ancestor-chain semantics (see vault_append_section). The heading line is preserved verbatim; everything between it and the next same-or-higher heading — including any nested subsections — is replaced with `content`. Pass an empty `content` to clear the section body. Frontmatter is untouched. Fails on path miss or ambiguous match. Unresolved `[[target]]` wiki-links auto-stub; `suggestedLinks` returns bare mentions. Returns `{ note, createdStubs, suggestedLinks }`.",
+      "PREFER THIS OVER vault_write when rewriting one section — surgical edit, keeps the rest of the note untouched. Replaces the body of a single heading-section. `headingPath` selects the section under strict-ancestor-chain semantics (see vault_append_section). The heading line is preserved verbatim; everything between it and the next same-or-higher heading — including any nested subsections — is replaced with `content`. Pass an empty `content` to clear the section body. Frontmatter is untouched. Fails on path miss or ambiguous match. Unresolved `[[target]]` wiki-links auto-stub; `suggestedLinks` returns bare mentions. Returns `{ note, createdStubs, suggestedLinks }`.",
     inputSchema: {
       id: z.string(),
       headingPath: z.array(z.string()).min(1),

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -114,7 +114,7 @@ server.registerTool(
   "vault_search",
   {
     description:
-      "REACH FOR THIS BEFORE Grep when you know a specific term (function name, env var, file name, error string). The vault indexes project docs, ADRs, runbooks, and gotchas — answers to 'what is X?' / 'where is X documented?' live here, not in the source tree. Matches against note title, tags, id, and body; title/tag/id hits are weighted higher so metadata matches still outrank body-only matches. Multi-word queries award extra points per token found in the body. Returns notes ranked by relevance. Status-aware: `status: deprecated` excluded by default, `status: stale` downranked. Pass `includeDeprecated: true` to include deprecated; `staleWeight` (0..1, default 0.7) tunes the stale penalty. Response shape: `{ results, truncated }`; `truncated: true` means lower-ranked results were dropped to fit `maxChars` (default 8000 ≈ 2000 tokens). Top result always returned. If this returns nothing for a term you expected to find, that's the signal the vault has a gap — consider `vault_create_note` after you finish the task.",
+      "REACH FOR THIS BEFORE Grep when you know a specific term (function name, env var, file name, error string). The vault indexes project docs, ADRs, runbooks, and gotchas — answers to 'what is X?' / 'where is X documented?' live here, not in the source tree. Matches title, tags, id, and body; metadata hits outrank body-only. Multi-word queries award extra points per token found in the body. Status-aware: `status: deprecated` excluded by default, `status: stale` downranked — override with `includeDeprecated` and `staleWeight` (0..1, default 0.7). Response shape: `{ results, truncated }`; `truncated: true` means lower-ranked results were dropped to fit `maxChars` (default 8000 ≈ 2000 tokens). Top result always returned.",
     inputSchema: {
       query: z.string(),
       limit: z.number().int().positive().optional(),
@@ -156,7 +156,7 @@ server.registerTool(
   "vault_read",
   {
     description:
-      "REACH FOR THIS BEFORE opening source files with Read when a vault_search / vault_semantic_search result points to a note id. Reads a single vault note by id (e.g. 'claude-code-vault/overview'). Returns full raw markdown plus forward links and backlinks. `resolvedTerms` is always present: when `resolveJargon` is true (default), it lists bare mentions of terms defined in any `type: glossary` note — each with `{ term, definition, source, sectionHeading }` — capped at 20 entries per read. When `resolveJargon: false`, it is an empty array. Mentions inside code fences/spans, `[[wiki-links]]`, and frontmatter are ignored; the note's own glossary terms (if it is itself a glossary) are never resolved back to itself.",
+      "REACH FOR THIS BEFORE opening source files with Read whenever you have a vault note id in hand (from search, tour, outline, a wiki-link, or a prior turn). Reads a single vault note by id (e.g. 'claude-code-vault/overview'). Returns full raw markdown plus forward links and backlinks. `resolvedTerms` is always present: when `resolveJargon` is true (default), it lists bare mentions of terms defined in any `type: glossary` note — each with `{ term, definition, source, sectionHeading }` — capped at 20 entries per read. When `resolveJargon: false`, it is an empty array. Mentions inside code fences/spans, `[[wiki-links]]`, and frontmatter are ignored; the note's own glossary terms (if it is itself a glossary) are never resolved back to itself.",
     inputSchema: {
       id: z.string(),
       resolveJargon: z.boolean().optional().default(true),
@@ -242,7 +242,7 @@ server.registerTool(
   "vault_related",
   {
     description:
-      "Get the 1-hop graph neighbors for a note: forward links and backlinks. Use this after vault_read to decide which neighbor to pull next; prefer vault_read_with_context if you know you'll want neighbor bodies in the same call.",
+      "CALL THIS AFTER vault_read to decide which neighbor to pull next. Returns the 1-hop graph neighbors for a note: forward links and backlinks. Prefer vault_read_with_context if you know you'll want neighbor bodies in the same call.",
     inputSchema: { id: z.string() },
   },
   safe(async ({ id }) => {
@@ -268,7 +268,7 @@ if (embeddingsDb) {
     "vault_semantic_search",
     {
       description:
-        "REACH FOR THIS FIRST — before Grep, before Read, before spawning a subagent — on any question-shaped task ('why does X happen?', 'how do we handle Y?', 'what's the approach for Z?'). The vault is this project's institutional memory: ADRs, design docs, runbooks, gotchas, past incidents. A single call here usually replaces 5+ Grep/Read round-trips and protects the main context window. If this returns nothing relevant, THEN fall back to filesystem search. Also call this on the task statement itself before spawning any Explore / general-purpose subagent, and pass the top 2-3 hits into the subagent's prompt as ground truth — subagents start cold and will otherwise re-derive what's already documented. Searches vault notes by meaning, not exact keywords. Returns notes ranked by cosine similarity of their best-matching chunk to the query, along with the heading path of that best chunk. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: deprecated notes are excluded and stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use when looking for notes *about* a concept (e.g. 'notes about authentication'). Pair with vault_read when you need the full note, or vault_search_chunks when you only need the most relevant paragraphs. Response shape: `{ results, truncated }` — lower-ranked matches are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top match is always returned.",
+        "REACH FOR THIS FIRST — before Grep, before Read, before spawning a subagent — on any question-shaped task. The vault is this project's institutional memory (ADRs, design docs, runbooks, gotchas). If this returns nothing relevant, fall back to filesystem search. Searches by meaning, not exact keywords: notes ranked by cosine similarity of their best-matching chunk, returned with that chunk's heading path. Pair with vault_read for the full note, or vault_search_chunks for just the passage. Pre-filters (applied before vector search, so `limit` counts the filtered subset): `folder` (id prefix), `tag` (string or array, any-match), `after`/`before` (YYYY-MM-DD on frontmatter `date`). Status-aware: deprecated notes excluded, stale downranked 0.7×; override with `includeDeprecated` and `staleWeight`. Response shape: `{ results, truncated }` — lower-ranked matches are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top match is always returned.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
@@ -323,7 +323,7 @@ if (embeddingsDb) {
     "vault_search_chunks",
     {
       description:
-        "REACH FOR THIS BEFORE Grep with context flags (-A/-B/-C) when you want one specific passage, not a whole note. Searches vault at the paragraph/section level. Returns the most semantically similar chunks (not whole notes), each with its heading breadcrumb (e.g. 'ADR-001 > Rationale > Why Workers'), the chunk text itself, any wiki-links it contains, and a similarity score. Supports optional pre-filters: `folder` (prefix match on note id), `tag` (string or array, any-match), and `after`/`before` (YYYY-MM-DD bounds on frontmatter `date`). Filters are applied *before* vector search, so `limit` counts results from the filtered subset. Status-aware: chunks from deprecated notes are excluded and chunks from stale notes are downranked (0.7×) by default — override with `includeDeprecated` and `staleWeight`. Use this when you want just the relevant passage — much cheaper than reading whole notes. Follow up with vault_read if the surrounding file context matters. Response shape: `{ results, truncated }` — lower-ranked chunks are dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); the top chunk is always returned even if its text alone exceeds the budget.",
+        "REACH FOR THIS BEFORE Grep -A/-B/-C when you want one specific passage, not a whole note. Searches at the paragraph/section level and returns chunks ranked by semantic similarity, each with its heading breadcrumb (e.g. 'ADR-001 > Rationale > Why Workers'), the text, any wiki-links, and a score. Follow up with vault_read if the surrounding file context matters. Pre-filters (applied before vector search, so `limit` counts the filtered subset): `folder` (id prefix), `tag` (string or array, any-match), `after`/`before` (YYYY-MM-DD on frontmatter `date`). Status-aware: chunks from deprecated notes excluded, stale downranked 0.7×; override with `includeDeprecated` and `staleWeight`. Response shape: `{ results, truncated }` — lower-ranked chunks dropped to fit `maxChars` (default 8000 ≈ 2000 tokens); top chunk always returned.",
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
@@ -378,7 +378,7 @@ if (embeddingsDb) {
     "vault_read_with_context",
     {
       description:
-        "REACH FOR THIS INSTEAD OF vault_read when you're likely to need the surrounding docs — saves multi-call fan-out. Reads a note AND its graph neighbors (notes it links to + notes that link to it) in one call. Each neighbor comes with its relation (forward/backlink/bidirectional), an edge weight (how many chunks reference it), and an intro snippet. Use this instead of vault_read when you want the surrounding context — saves round-trips. Bounded by maxChars (default 8000); `truncated: true` in the response means some snippets were trimmed or neighbors dropped.",
+        "REACH FOR THIS INSTEAD OF vault_read when you're likely to need the surrounding docs — saves multi-call fan-out. Reads a note AND its graph neighbors (notes it links to + notes that link to it) in one call. Each neighbor comes with its relation (forward/backlink/bidirectional), an edge weight (how many chunks reference it), and an intro snippet. Bounded by maxChars (default 8000); `truncated: true` means some snippets were trimmed or neighbors dropped.",
       inputSchema: {
         id: z.string(),
         depth: z.number().int().min(1).max(2).optional(),
@@ -525,7 +525,7 @@ server.registerTool(
   "vault_tour",
   {
     description:
-      "REACH FOR THIS AT SESSION START BEFORE exploring directories with Glob/ls — it's the fastest way to orient in an unfamiliar vault. Returns the top-`limit` most important notes in the vault, ranked by graph centrality (PageRank, damping 0.85, blended 70/30 with inbound-degree). Use at the start of a new session to orient an agent in the vault without walking links manually. Deprecated notes are excluded; stale notes are downweighted (0.7×). VAULT_SUMMARY / overview notes get a seed bias so new sessions land on orientation first. `folder` is an optional id-prefix filter (e.g. 'claude-code-vault' — matches any note whose id begins with that prefix, consistent with `folder` on vault_semantic_search). Response shape: `{ results, truncated }`. Each result: `{ id, title, summary, type, pageRank, status }`. Default `limit` 10 (max 200). Bounded by `maxChars` (default 8000 ≈ 2000 tokens).",
+      "REACH FOR THIS AT SESSION START BEFORE exploring directories with Glob/ls — fastest way to orient in an unfamiliar vault. Returns the top-`limit` most important notes, ranked by graph centrality (PageRank, damping 0.85, blended 70/30 with inbound-degree). Deprecated excluded, stale downweighted 0.7×. VAULT_SUMMARY / overview notes get a seed bias so new sessions land on orientation first. `folder` is an optional id-prefix filter (e.g. 'claude-code-vault'). Response shape: `{ results, truncated }`. Each result: `{ id, title, summary, type, pageRank, status }`. Default `limit` 10 (max 200). Bounded by `maxChars` (default 8000 ≈ 2000 tokens).",
     inputSchema: {
       folder: z.string().min(1).optional(),
       limit: z.number().int().positive().max(200).optional(),
@@ -559,7 +559,7 @@ server.registerTool(
   "vault_outline",
   {
     description:
-      "REACH FOR THIS INSTEAD OF reading multiple notes to understand a folder — skimmable TOC of titles + headings, no JSON parsing. Returns a plain-text table of contents for the vault — each note's title + top `maxDepth` heading levels. Cheap, skimmable, no JSON parsing required. Use to understand the shape of a folder without reading full notes. Structure per note: a `# title (id)` line followed by indented `##`/`###` headings. Deprecated notes are excluded. `folder` is an optional id-prefix filter (consistent with `folder` on vault_semantic_search). Default `maxDepth` 2 (H2 only below the title line). Headings inside fenced code blocks are skipped. Response shape: `{ outline, truncated, noteCount }` — `outline` is the packed markdown text; if it exceeds `maxChars` (default 8000) it is cut at a whole-note boundary with a trailing `[truncated: N notes omitted]` marker and `truncated` is `true`.",
+      "REACH FOR THIS INSTEAD OF reading multiple notes to understand a folder — skimmable TOC of titles + headings, no JSON parsing. Returns a plain-text table of contents: each note's title + top `maxDepth` heading levels. Structure per note: a `# title (id)` line followed by indented `##`/`###` headings. Deprecated excluded. `folder` is an optional id-prefix filter. Default `maxDepth` 2 (H2 only). Headings inside fenced code blocks are skipped. Response shape: `{ outline, truncated, noteCount }` — `outline` is the packed markdown text; if it exceeds `maxChars` (default 8000) it is cut at a whole-note boundary with a trailing `[truncated: N notes omitted]` marker and `truncated` is `true`.",
     inputSchema: {
       folder: z.string().min(1).optional(),
       maxDepth: z.number().int().min(1).max(6).optional(),


### PR DESCRIPTION
## Summary

Rewrites every \`vault_*\` MCP tool description to lead with explicit routing against Grep / Read / Glob / subagent-spawn. The MCP description is the LLM's first signal when choosing a tool; today's descriptions compete on features instead of naming *when to reach for them*.

This is priority (1) from the enforcement-gap analysis — lowest-risk, highest-leverage. Remaining priorities tracked in #61 (consolidation), #62 (Grep/Glob hook), #63 (Agent hook), #64 (session-end hook).

## Changes

**Read-side (route away from Grep/Read):**
- \`vault_semantic_search\` — "REACH FOR THIS FIRST" on question-shaped queries; names the subagent-context-isolation trap and mandates passing top hits into subagent prompts
- \`vault_search\` — "BEFORE Grep when you know a specific term"; empty result = vault gap signal
- \`vault_read\` / \`vault_read_with_context\` — "BEFORE Read" when a search points to a note id
- \`vault_search_chunks\` / \`_with_context\` — "BEFORE Grep -A/-B/-C"
- \`vault_list\` / \`vault_tour\` / \`vault_outline\` — "BEFORE Glob / ls" for orientation

**Write-side (signal when each is right):**
- \`vault_create_note\` — close the loop after an empty search
- \`vault_write\` / \`vault_append_section\` / \`vault_replace_section\` — prefer surgical edits over full-note rewrites
- \`vault_lint\` — before committing a new note

## Why

Subagents don't inherit CLAUDE.md. Even when the orchestrator knows the rule, the description is the one contract every LLM client reads. Leading each description with \"REACH FOR THIS BEFORE X\" turns advice into routing.

## Test plan

- [x] \`node --check lib/mcp.js\` passes
- [x] Smoke: server boots with a minimal vault
- [ ] After merge + publish: verify in PoseVision that vault_* tools win over Grep for a representative query