### PR TITLE
feat(hooks): vault-first reminder for Grep/Glob (closes #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,30 @@ node index.js read-with-context claude-code-vault/adrs/adr-001-local-first-embed
 node index.js search-with-context "tab throttling" --limit 3 --depth 2
 ```
 
+## Vault-first hook (optional)
+
+Tool descriptions nudge agents to reach for the vault before Grep/Read, but they're advisory — an agent habituated to filesystem search can still skip the vault. A PreToolUse hook makes the nudge guaranteed.
+
+Wire it into `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep|Glob",
+        "hooks": [{
+          "type": "command",
+          "command": "node ./node_modules/claude-code-vault/hooks/vault-first-reminder.mjs"
+        }]
+      }
+    ]
+  }
+}
+```
+
+On the **first** Grep or Glob per session, the hook emits a reminder with `vault_semantic_search` pre-formulated from the search pattern. Every subsequent Grep/Glob is silent — this is a once-per-session nudge, not a gate. Never blocks the underlying tool. State lives in `/tmp/claude-code-vault-hook-state/`. Disable per-session with `CLAUDE_VAULT_HOOK_DISABLE=1`.
+
 ## Roadmap
 
 Full roadmap tracker: **[#33 — LLM-first documentation](https://github.com/bernabranco/claude-code-vault/issues/33)**.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Wire it into `.claude/settings.json`:
         "matcher": "Grep|Glob",
         "hooks": [{
           "type": "command",
-          "command": "node ./node_modules/claude-code-vault/hooks/vault-first-reminder.mjs"
+          "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-first-reminder.mjs"
         }]
       }
     ]
@@ -188,7 +188,7 @@ Wire it into `.claude/settings.json`:
 }
 ```
 
-On the **first** Grep or Glob per session, the hook emits a reminder with `vault_semantic_search` pre-formulated from the search pattern. Every subsequent Grep/Glob is silent — this is a once-per-session nudge, not a gate. Never blocks the underlying tool. State lives in `/tmp/claude-code-vault-hook-state/`. Disable per-session with `CLAUDE_VAULT_HOOK_DISABLE=1`.
+On the **first** Grep or Glob per session, the hook emits a reminder with `vault_semantic_search` pre-formulated from the search pattern. Every subsequent Grep/Glob is silent — this is a once-per-session nudge, not a gate. Never blocks the underlying tool. State lives under the OS temp dir at `claude-code-vault-hook-state/<session_id>.seen` (sanitized). To disable, export `CLAUDE_VAULT_HOOK_DISABLE=1` in the shell Claude Code inherits.
 
 ## Roadmap
 

--- a/hooks/vault-first-reminder.mjs
+++ b/hooks/vault-first-reminder.mjs
@@ -9,7 +9,7 @@
 //           "matcher": "Grep|Glob",
 //           "hooks": [{
 //             "type": "command",
-//             "command": "node /absolute/path/to/hooks/vault-first-reminder.mjs"
+//             "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-first-reminder.mjs"
 //           }]
 //         }
 //       ]
@@ -18,12 +18,13 @@
 //
 // Behavior: on the FIRST Grep or Glob call per session, emits additionalContext
 // suggesting `vault_semantic_search` with the pattern pre-formulated. Silent on
-// every subsequent call. Never blocks — this is a nudge, not a gate.
+// every subsequent call. Never emits a "block" decision — this hook is a nudge,
+// not a gate. Future edits must preserve that invariant.
 //
-// Disable per-session: set env CLAUDE_VAULT_HOOK_DISABLE=1
-// Reset state: delete the state dir (printed below on first run).
+// Disable: export CLAUDE_VAULT_HOOK_DISABLE=1 in the shell Claude Code inherits.
+// State: <os.tmpdir()>/claude-code-vault-hook-state/<sanitized-session-id>.seen
 
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -45,11 +46,18 @@ function main() {
     process.exit(0);
   }
 
-  const sessionId = payload.session_id || "unknown";
+  const rawSessionId = payload.session_id;
   const toolName = payload.tool_name || "";
   const toolInput = payload.tool_input || {};
 
   if (toolName !== "Grep" && toolName !== "Glob") process.exit(0);
+
+  // Missing session id → exit silently rather than collide on a shared flag.
+  if (!rawSessionId || typeof rawSessionId !== "string") process.exit(0);
+
+  // Sanitize session id before using it as a filename (avoid path traversal).
+  const sessionId = rawSessionId.replaceAll(/[^a-zA-Z0-9_-]/g, "_").slice(0, 128);
+  if (!sessionId) process.exit(0);
 
   const stateDir = join(tmpdir(), "claude-code-vault-hook-state");
   try {
@@ -59,25 +67,28 @@ function main() {
   }
 
   const flag = join(stateDir, `${sessionId}.seen`);
-  if (existsSync(flag)) process.exit(0);
-
+  // Exclusive create — if another concurrent first-call already wrote it, we bail.
   try {
-    writeFileSync(flag, new Date().toISOString());
+    writeFileSync(flag, new Date().toISOString(), { flag: "wx" });
   } catch {
     process.exit(0);
   }
 
-  const query = String(toolInput.pattern || toolInput.query || toolInput.path || "").slice(0, 200);
+  // Sanitize the pattern before echoing: strip control chars and backticks so
+  // an attacker-controlled Grep pattern can't inject instructions into the
+  // additionalContext payload Claude reads. JSON.stringify handles wire-safety.
+  const rawQuery = String(toolInput.pattern || toolInput.query || toolInput.path || "");
+  const query = rawQuery.replaceAll(/[`\u0000-\u001f]/g, " ").slice(0, 200).trim();
   const suggestion = query
-    ? `\`vault_semantic_search({ query: "${query.replace(/"/g, '\\"')}" })\``
-    : "`vault_semantic_search`";
+    ? `vault_semantic_search with query: "${query}"`
+    : "vault_semantic_search";
 
   const message = [
     "Vault-first reminder (fires once per session).",
     "",
-    `Before searching the filesystem with ${toolName}, consider the vault — it indexes this project's ADRs, design docs, runbooks, and gotchas. Question-shaped intent? Try ${suggestion}. Known term? Try \`vault_search\`.`,
+    `Before searching the filesystem with ${toolName}, consider the vault — it indexes this project's ADRs, design docs, runbooks, and gotchas. Question-shaped intent? Try ${suggestion}. Known term? Try vault_search.`,
     "",
-    "If the vault has no relevant note, the Grep will still proceed — this message does not block.",
+    `If the vault has no relevant note, the ${toolName} will still proceed — this message does not block.`,
   ].join("\n");
 
   process.stdout.write(

--- a/hooks/vault-first-reminder.mjs
+++ b/hooks/vault-first-reminder.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// PreToolUse hook for Grep / Glob — reminds Claude to try the vault first.
+//
+// Wire into .claude/settings.json:
+//   {
+//     "hooks": {
+//       "PreToolUse": [
+//         {
+//           "matcher": "Grep|Glob",
+//           "hooks": [{
+//             "type": "command",
+//             "command": "node /absolute/path/to/hooks/vault-first-reminder.mjs"
+//           }]
+//         }
+//       ]
+//     }
+//   }
+//
+// Behavior: on the FIRST Grep or Glob call per session, emits additionalContext
+// suggesting `vault_semantic_search` with the pattern pre-formulated. Silent on
+// every subsequent call. Never blocks — this is a nudge, not a gate.
+//
+// Disable per-session: set env CLAUDE_VAULT_HOOK_DISABLE=1
+// Reset state: delete the state dir (printed below on first run).
+
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function readStdinSync() {
+  try {
+    return readFileSync(0, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function main() {
+  if (process.env.CLAUDE_VAULT_HOOK_DISABLE === "1") process.exit(0);
+
+  let payload;
+  try {
+    payload = JSON.parse(readStdinSync() || "{}");
+  } catch {
+    process.exit(0);
+  }
+
+  const sessionId = payload.session_id || "unknown";
+  const toolName = payload.tool_name || "";
+  const toolInput = payload.tool_input || {};
+
+  if (toolName !== "Grep" && toolName !== "Glob") process.exit(0);
+
+  const stateDir = join(tmpdir(), "claude-code-vault-hook-state");
+  try {
+    mkdirSync(stateDir, { recursive: true });
+  } catch {
+    process.exit(0);
+  }
+
+  const flag = join(stateDir, `${sessionId}.seen`);
+  if (existsSync(flag)) process.exit(0);
+
+  try {
+    writeFileSync(flag, new Date().toISOString());
+  } catch {
+    process.exit(0);
+  }
+
+  const query = String(toolInput.pattern || toolInput.query || toolInput.path || "").slice(0, 200);
+  const suggestion = query
+    ? `\`vault_semantic_search({ query: "${query.replace(/"/g, '\\"')}" })\``
+    : "`vault_semantic_search`";
+
+  const message = [
+    "Vault-first reminder (fires once per session).",
+    "",
+    `Before searching the filesystem with ${toolName}, consider the vault — it indexes this project's ADRs, design docs, runbooks, and gotchas. Question-shaped intent? Try ${suggestion}. Known term? Try \`vault_search\`.`,
+    "",
+    "If the vault has no relevant note, the Grep will still proceed — this message does not block.",
+  ].join("\n");
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: message,
+      },
+    })
+  );
+  process.exit(0);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "files": [
     "index.js",
-    "lib/"
+    "lib/",
+    "hooks/"
   ],
   "scripts": {
     "dev": "concurrently \"node --watch lib/server.js\" \"cd web && npm run dev\"",


### PR DESCRIPTION
## Summary

Ships the first of the enforcement-gap hooks from the analysis. Tool descriptions (#65) nudge agents to reach for the vault first, but they're advisory — an agent habituated to Grep can still skip the vault, especially in spawned subagents that never read CLAUDE.md. This hook makes the nudge guaranteed.

- \`hooks/vault-first-reminder.mjs\` — zero-dep Node script, Claude Code PreToolUse protocol
- Fires ONCE per session on the first \`Grep\` or \`Glob\` call, silent thereafter
- Emits \`hookSpecificOutput.additionalContext\` suggesting \`vault_semantic_search\` with the query pre-formulated from the tool pattern
- **Never blocks** — this is a nudge, not a gate. The original Grep/Glob still runs.
- Opt-in via \`.claude/settings.json\` (documented in README)
- Disable per-session with \`CLAUDE_VAULT_HOOK_DISABLE=1\`
- State lives in \`/tmp/claude-code-vault-hook-state/<session_id>.seen\`

## Wiring (added to README)

\`\`\`json
{
  \"hooks\": {
    \"PreToolUse\": [
      {
        \"matcher\": \"Grep|Glob\",
        \"hooks\": [{
          \"type\": \"command\",
          \"command\": \"node ./node_modules/claude-code-vault/hooks/vault-first-reminder.mjs\"
        }]
      }
    ]
  }
}
\`\`\`

## Test plan

- [x] \`node --check hooks/vault-first-reminder.mjs\` passes
- [x] Smoke-tested 5 branches: first Grep fires, same-session Glob silent, new session fires, non-Grep/Glob tools ignored, \`CLAUDE_VAULT_HOOK_DISABLE=1\` honored
- [ ] After merge + publish: wire into PoseVision's \`.claude/settings.json\` and confirm the nudge fires on the next Grep-heavy session

## Follow-ups

- #61 — collapse 13 \`vault_*\` tools into 4
- #63 — Agent spawn hook (blocks subagent spawn without prior vault query)
- #64 — session-end gap report

Closes #62.