### PR TITLE
feat(hooks): subagent-spawn vault gate (closes #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,28 @@ Wire it into `.claude/settings.json`:
 
 On the **first** Grep or Glob per session, the hook emits a reminder with `vault_semantic_search` pre-formulated from the search pattern. Every subsequent Grep/Glob is silent — this is a once-per-session nudge, not a gate. Never blocks the underlying tool. State lives under the OS temp dir at `claude-code-vault-hook-state/<session_id>.seen` (sanitized). To disable, export `CLAUDE_VAULT_HOOK_DISABLE=1` in the shell Claude Code inherits.
 
+### Subagent gate (stronger enforcement)
+
+A second hook **blocks** subagent spawns when no `vault_*` tool has been called in the recent conversation. Subagents don't inherit CLAUDE.md and start cold, so spawning without vault context usually wastes tokens re-deriving what's already documented.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [{
+          "type": "command",
+          "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-first-subagent.mjs"
+        }]
+      }
+    ]
+  }
+}
+```
+
+The hook reads the last ~256 KB of Claude Code's transcript, scans the last 20 tool uses (override with `CLAUDE_VAULT_SUBAGENT_LOOKBACK=N`), and allows the spawn if any `vault_*` tool appears. Otherwise it denies with a reason suggesting the vault query pre-formulated from the subagent's task description. Fails open on any error — missing transcript, parse failure, etc. — so a broken hook can never brick your workflow. Disable with `CLAUDE_VAULT_HOOK_DISABLE=1` (same env var as the Grep/Glob nudge).
+
 ## Roadmap
 
 Full roadmap tracker: **[#33 — LLM-first documentation](https://github.com/bernabranco/claude-code-vault/issues/33)**.

--- a/hooks/vault-first-subagent.mjs
+++ b/hooks/vault-first-subagent.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// PreToolUse hook for Agent — blocks subagent spawn if no vault_* tool has
+// been used in the recent conversation. Subagents don't inherit CLAUDE.md
+// and start cold, so spawning without vault context wastes tokens
+// re-deriving what's already documented.
+//
+// Wire into .claude/settings.json:
+//   {
+//     "hooks": {
+//       "PreToolUse": [
+//         {
+//           "matcher": "Agent",
+//           "hooks": [{
+//             "type": "command",
+//             "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-first-subagent.mjs"
+//           }]
+//         }
+//       ]
+//     }
+//   }
+//
+// Behavior: scans the tail of the Claude Code transcript for recent vault_*
+// tool_use entries. If any are found within the last N assistant tool-use
+// entries (default 20), the spawn is allowed. Otherwise the hook returns
+// permissionDecision: "deny" with a reason telling the orchestrator to
+// query the vault first.
+//
+// Fail-open on any error (missing transcript, parse failure, missing
+// input) — we never want to brick the user's workflow.
+//
+// Tunables:
+//   CLAUDE_VAULT_HOOK_DISABLE=1   — disable entirely
+//   CLAUDE_VAULT_SUBAGENT_LOOKBACK=N — override the 20-tool-use lookback window
+
+import { readFileSync, statSync } from "node:fs";
+
+const DEFAULT_LOOKBACK = 20;
+const MAX_TAIL_BYTES = 256 * 1024; // Cap transcript read to keep work bounded.
+
+function readStdinSync() {
+  try {
+    return readFileSync(0, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function readTranscriptTail(transcriptPath) {
+  try {
+    const stat = statSync(transcriptPath);
+    const start = Math.max(0, stat.size - MAX_TAIL_BYTES);
+    const raw = readFileSync(transcriptPath, { encoding: "utf-8", flag: "r" });
+    return start === 0 ? raw : raw.slice(start);
+  } catch {
+    return "";
+  }
+}
+
+function countRecentVaultCalls(transcriptTail, lookback) {
+  if (!transcriptTail) return { toolUses: 0, vaultUses: 0 };
+
+  const lines = transcriptTail.split("\n").filter(Boolean);
+  let toolUses = 0;
+  let vaultUses = 0;
+
+  // Walk the tail in reverse; stop once we've seen `lookback` tool uses.
+  for (let i = lines.length - 1; i >= 0 && toolUses < lookback; i--) {
+    let entry;
+    try {
+      entry = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
+
+    // Claude Code transcripts are JSONL. Each line is typically a message
+    // object. We look for tool_use content blocks in assistant messages.
+    const message = entry?.message ?? entry;
+    const content = message?.content;
+    if (!Array.isArray(content)) continue;
+
+    for (const block of content) {
+      if (block?.type !== "tool_use") continue;
+      toolUses++;
+      const name = String(block.name || "");
+      if (name.startsWith("vault_") || name.includes("__vault_")) {
+        vaultUses++;
+      }
+      if (toolUses >= lookback) break;
+    }
+  }
+
+  return { toolUses, vaultUses };
+}
+
+function emitAllow() {
+  // No output = allow; simplest possible path.
+  process.exit(0);
+}
+
+function emitBlock(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    })
+  );
+  process.exit(0);
+}
+
+function main() {
+  if (process.env.CLAUDE_VAULT_HOOK_DISABLE === "1") emitAllow();
+
+  let payload;
+  try {
+    payload = JSON.parse(readStdinSync() || "{}");
+  } catch {
+    emitAllow();
+  }
+
+  if (payload.tool_name !== "Agent" && payload.tool_name !== "Task") emitAllow();
+
+  const transcriptPath = payload.transcript_path;
+  if (!transcriptPath || typeof transcriptPath !== "string") emitAllow();
+
+  const lookback = Math.max(
+    1,
+    Math.min(
+      200,
+      parseInt(process.env.CLAUDE_VAULT_SUBAGENT_LOOKBACK || "", 10) || DEFAULT_LOOKBACK
+    )
+  );
+
+  const tail = readTranscriptTail(transcriptPath);
+  if (!tail) emitAllow(); // Fail-open: no transcript, no evidence, allow.
+
+  const { vaultUses } = countRecentVaultCalls(tail, lookback);
+  if (vaultUses > 0) emitAllow();
+
+  const taskDescription = String(payload?.tool_input?.description || payload?.tool_input?.prompt || "")
+    .replaceAll(/[`\u0000-\u001f]/g, " ")
+    .slice(0, 200)
+    .trim();
+
+  const reasonLines = [
+    "Subagent spawn blocked: no vault_* tool has been called in the last",
+    `${lookback} tool uses. Subagents start cold — they do NOT read CLAUDE.md`,
+    "and will re-derive patterns already documented in the vault.",
+    "",
+    "Before spawning, call vault_semantic_search on the task statement",
+    taskDescription ? `(e.g. query: "${taskDescription}") ` : "",
+    "and pass the top 2-3 hits into the subagent's prompt as ground truth.",
+    "",
+    "To bypass for this session: export CLAUDE_VAULT_HOOK_DISABLE=1",
+  ].filter(Boolean);
+
+  emitBlock(reasonLines.join("\n"));
+}
+
+main();

--- a/hooks/vault-first-subagent.mjs
+++ b/hooks/vault-first-subagent.mjs
@@ -9,7 +9,7 @@
 //     "hooks": {
 //       "PreToolUse": [
 //         {
-//           "matcher": "Agent",
+//           "matcher": "Agent|Task",
 //           "hooks": [{
 //             "type": "command",
 //             "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-first-subagent.mjs"
@@ -32,7 +32,8 @@
 //   CLAUDE_VAULT_HOOK_DISABLE=1   — disable entirely
 //   CLAUDE_VAULT_SUBAGENT_LOOKBACK=N — override the 20-tool-use lookback window
 
-import { readFileSync, statSync } from "node:fs";
+import { closeSync, openSync, readFileSync, readSync, statSync } from "node:fs";
+import { isAbsolute } from "node:path";
 
 const DEFAULT_LOOKBACK = 20;
 const MAX_TAIL_BYTES = 256 * 1024; // Cap transcript read to keep work bounded.
@@ -45,14 +46,36 @@ function readStdinSync() {
   }
 }
 
+function isSafeTranscriptPath(p) {
+  // Accept only absolute paths to a .jsonl file. transcript_path comes from
+  // Claude Code; a malformed value must not cause us to read arbitrary files.
+  return typeof p === "string" && isAbsolute(p) && p.endsWith(".jsonl");
+}
+
 function readTranscriptTail(transcriptPath) {
+  // Truly bounded read: open the file, seek to (size - MAX_TAIL_BYTES), read
+  // at most MAX_TAIL_BYTES. Never load the whole transcript into memory even
+  // if it grows into the megabytes.
+  let fd = -1;
   try {
-    const stat = statSync(transcriptPath);
-    const start = Math.max(0, stat.size - MAX_TAIL_BYTES);
-    const raw = readFileSync(transcriptPath, { encoding: "utf-8", flag: "r" });
-    return start === 0 ? raw : raw.slice(start);
+    const size = statSync(transcriptPath).size;
+    const start = Math.max(0, size - MAX_TAIL_BYTES);
+    const len = size - start;
+    if (len <= 0) return "";
+    fd = openSync(transcriptPath, "r");
+    const buf = Buffer.alloc(len);
+    readSync(fd, buf, 0, len, start);
+    return buf.toString("utf-8");
   } catch {
     return "";
+  } finally {
+    if (fd >= 0) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
   }
 }
 
@@ -73,16 +96,21 @@ function countRecentVaultCalls(transcriptTail, lookback) {
     }
 
     // Claude Code transcripts are JSONL. Each line is typically a message
-    // object. We look for tool_use content blocks in assistant messages.
+    // object. We only count tool_use blocks from assistant messages — user
+    // messages carry tool_result replies which can embed tool_use references
+    // that must not be counted as fresh invocations.
     const message = entry?.message ?? entry;
+    if (message?.role && message.role !== "assistant") continue;
     const content = message?.content;
     if (!Array.isArray(content)) continue;
 
     for (const block of content) {
       if (block?.type !== "tool_use") continue;
       toolUses++;
+      // MCP-namespaced form: mcp__<server>__vault_<name>. The startsWith
+      // branch covers direct (non-MCP) invocation used in tests.
       const name = String(block.name || "");
-      if (name.startsWith("vault_") || name.includes("__vault_")) {
+      if (name.includes("__vault_") || name.startsWith("vault_")) {
         vaultUses++;
       }
       if (toolUses >= lookback) break;
@@ -111,19 +139,21 @@ function emitBlock(reason) {
 }
 
 function main() {
-  if (process.env.CLAUDE_VAULT_HOOK_DISABLE === "1") emitAllow();
+  // emitAllow/emitBlock below both call process.exit(0) — these guards rely on
+  // that to short-circuit. Any future refactor must preserve that invariant.
+  if (process.env.CLAUDE_VAULT_HOOK_DISABLE === "1") return emitAllow();
 
   let payload;
   try {
     payload = JSON.parse(readStdinSync() || "{}");
   } catch {
-    emitAllow();
+    return emitAllow();
   }
 
-  if (payload.tool_name !== "Agent" && payload.tool_name !== "Task") emitAllow();
+  if (payload.tool_name !== "Agent" && payload.tool_name !== "Task") return emitAllow();
 
   const transcriptPath = payload.transcript_path;
-  if (!transcriptPath || typeof transcriptPath !== "string") emitAllow();
+  if (!isSafeTranscriptPath(transcriptPath)) return emitAllow();
 
   const lookback = Math.max(
     1,
@@ -134,13 +164,13 @@ function main() {
   );
 
   const tail = readTranscriptTail(transcriptPath);
-  if (!tail) emitAllow(); // Fail-open: no transcript, no evidence, allow.
+  if (!tail) return emitAllow(); // Fail-open: no transcript, no evidence, allow.
 
   const { vaultUses } = countRecentVaultCalls(tail, lookback);
-  if (vaultUses > 0) emitAllow();
+  if (vaultUses > 0) return emitAllow();
 
   const taskDescription = String(payload?.tool_input?.description || payload?.tool_input?.prompt || "")
-    .replaceAll(/[`\u0000-\u001f]/g, " ")
+    .replaceAll(/[`"\u0000-\u001f]/g, " ")
     .slice(0, 200)
     .trim();
 
@@ -150,7 +180,7 @@ function main() {
     "and will re-derive patterns already documented in the vault.",
     "",
     "Before spawning, call vault_semantic_search on the task statement",
-    taskDescription ? `(e.g. query: "${taskDescription}") ` : "",
+    taskDescription ? `(e.g. query: ${JSON.stringify(taskDescription)}) ` : "",
     "and pass the top 2-3 hits into the subagent's prompt as ground truth.",
     "",
     "To bypass for this session: export CLAUDE_VAULT_HOOK_DISABLE=1",


### PR DESCRIPTION
## Summary

Second of three enforcement-gap hooks. Where #62 (shipped) **nudges** on Grep/Glob, this hook **blocks** subagent spawns when no \`vault_*\` tool has been called in the recent conversation.

The motivating failure: the PoseVision Explore subagent transcript that ran 40+ Bash/Glob/Read calls while never touching a vault tool. Subagents don't inherit CLAUDE.md, so the orchestrator is the only place to enforce vault-first discipline.

## How it works

- Matcher: \`Agent|Task\` PreToolUse
- Reads the last 256 KB of Claude Code's \`transcript_path\`
- Walks recent \`tool_use\` blocks in reverse, stops after \`lookback\` entries (default 20, env-tunable)
- Any \`vault_*\` tool in the window → allow silently
- None → \`permissionDecision: \"deny\"\` with a reason that includes \`vault_semantic_search(query: \"<sanitized task description>\")\`
- **Fail-open** on any error (missing transcript, parse failure, missing session) — can never brick the workflow
- \`CLAUDE_VAULT_HOOK_DISABLE=1\` bypasses (shared env with #62)
- \`CLAUDE_VAULT_SUBAGENT_LOOKBACK=N\` tunes the window (clamped 1..200)

## Test plan

- [x] \`node --check hooks/vault-first-subagent.mjs\` passes
- [x] 9-branch smoke test: non-Agent silent, no-vault blocks with task-aware reason, vault-present allows, lookback honored, fail-open on missing/bogus/corrupt transcripts, disable env works, Task alias gated
- [ ] After merge + publish: wire into PoseVision \`.claude/settings.json\` and validate on a real subagent spawn

## Follow-up

- #64 — session-end gap report (files touched vs vault queried)

Closes #63.