### PR TITLE
feat(hooks): end-of-session gap report (closes #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,25 @@ A second hook **blocks** subagent spawns when no `vault_*` tool has been called 
 
 The hook reads the last ~256 KB of Claude Code's transcript, scans the last 20 tool uses (override with `CLAUDE_VAULT_SUBAGENT_LOOKBACK=N`), and allows the spawn if any `vault_*` tool appears. Otherwise it denies with a reason suggesting the vault query pre-formulated from the subagent's task description. Fails open on any error — missing transcript, parse failure, etc. — so a broken hook can never brick your workflow. Disable with `CLAUDE_VAULT_HOOK_DISABLE=1` (same env var as the Grep/Glob nudge).
 
+### End-of-session gap report
+
+A third hook closes the write-loop. At session end, it scans the transcript and flags sessions that edited multiple files but never queried the vault — the signal that the next agent will re-derive whatever was just learned.
+
+```json
+{
+  "hooks": {
+    "SessionEnd": [{
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-gap-report.mjs"
+      }]
+    }]
+  }
+}
+```
+
+If the session edited ≥ `CLAUDE_VAULT_GAP_THRESHOLD` (default 3) distinct files AND called zero `vault_*` tools, the hook prints a concise report to stderr (visible to the user, NOT injected into the model) suggesting `vault_create_note` on the way out. Silent otherwise. Never blocks.
+
 ## Roadmap
 
 Full roadmap tracker: **[#33 — LLM-first documentation](https://github.com/bernabranco/claude-code-vault/issues/33)**.

--- a/hooks/vault-gap-report.mjs
+++ b/hooks/vault-gap-report.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// SessionEnd / Stop hook — reports a "gap" when the session edited files
+// but never queried the vault. Closes the write-loop: makes forgetting to
+// document a learning the default-visible failure mode instead of silent.
+//
+// Wire into .claude/settings.json (choose ONE trigger event):
+//
+//   {
+//     "hooks": {
+//       "SessionEnd": [{
+//         "hooks": [{
+//           "type": "command",
+//           "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-gap-report.mjs"
+//         }]
+//       }]
+//     }
+//   }
+//
+// Or use `Stop` if you want the report to appear mid-session when Claude
+// finishes a turn. SessionEnd is less noisy.
+//
+// Behavior: scans the full transcript tail (last 1 MB), collects:
+//   - distinct file paths written by Edit/Write/NotebookEdit
+//   - vault_* tool uses
+// If at least CLAUDE_VAULT_GAP_THRESHOLD (default 3) distinct files were
+// edited AND zero vault tools were called, prints a concise reminder to
+// stderr (visible to the user, NOT injected into the model context).
+// Silent otherwise. Never blocks — always exit 0.
+//
+// Tunables:
+//   CLAUDE_VAULT_HOOK_DISABLE=1       — disable entirely
+//   CLAUDE_VAULT_GAP_THRESHOLD=N      — minimum distinct edits to trigger (default 3)
+
+import { closeSync, openSync, readFileSync, readSync, statSync } from "node:fs";
+import { isAbsolute } from "node:path";
+
+const DEFAULT_THRESHOLD = 3;
+const MAX_TAIL_BYTES = 1024 * 1024;
+const EDIT_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "MultiEdit"]);
+
+function readStdinSync() {
+  try {
+    return readFileSync(0, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function isSafeTranscriptPath(p) {
+  return typeof p === "string" && isAbsolute(p) && p.endsWith(".jsonl");
+}
+
+function readTranscriptTail(transcriptPath) {
+  let fd = -1;
+  try {
+    const size = statSync(transcriptPath).size;
+    const start = Math.max(0, size - MAX_TAIL_BYTES);
+    const len = size - start;
+    if (len <= 0) return "";
+    fd = openSync(transcriptPath, "r");
+    const buf = Buffer.alloc(len);
+    readSync(fd, buf, 0, len, start);
+    return buf.toString("utf-8");
+  } catch {
+    return "";
+  } finally {
+    if (fd >= 0) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+function collectToolUses(transcriptTail) {
+  const editedFiles = new Set();
+  let vaultUses = 0;
+
+  if (!transcriptTail) return { editedFiles, vaultUses };
+
+  const lines = transcriptTail.split("\n").filter(Boolean);
+  for (const line of lines) {
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const message = entry?.message ?? entry;
+    if (message?.role && message.role !== "assistant") continue;
+    const content = message?.content;
+    if (!Array.isArray(content)) continue;
+
+    for (const block of content) {
+      if (block?.type !== "tool_use") continue;
+      const name = String(block.name || "");
+      if (name.includes("__vault_") || name.startsWith("vault_")) {
+        vaultUses++;
+        continue;
+      }
+      const bare = name.includes("__") ? name.split("__").pop() : name;
+      if (EDIT_TOOLS.has(bare)) {
+        const fp = block?.input?.file_path || block?.input?.notebook_path;
+        if (typeof fp === "string" && fp.length > 0) editedFiles.add(fp);
+      }
+    }
+  }
+
+  return { editedFiles, vaultUses };
+}
+
+function main() {
+  if (process.env.CLAUDE_VAULT_HOOK_DISABLE === "1") process.exit(0);
+
+  let payload;
+  try {
+    payload = JSON.parse(readStdinSync() || "{}");
+  } catch {
+    process.exit(0);
+  }
+
+  const transcriptPath = payload.transcript_path;
+  if (!isSafeTranscriptPath(transcriptPath)) process.exit(0);
+
+  const threshold = Math.max(
+    1,
+    Math.min(
+      100,
+      parseInt(process.env.CLAUDE_VAULT_GAP_THRESHOLD || "", 10) || DEFAULT_THRESHOLD
+    )
+  );
+
+  const tail = readTranscriptTail(transcriptPath);
+  if (!tail) process.exit(0);
+
+  const { editedFiles, vaultUses } = collectToolUses(tail);
+
+  // Trigger condition: meaningful edits AND zero vault engagement.
+  if (editedFiles.size < threshold || vaultUses > 0) process.exit(0);
+
+  const sampleFiles = [...editedFiles].slice(0, 5);
+  const more = editedFiles.size - sampleFiles.length;
+
+  const message = [
+    "",
+    "─── vault-gap-report ───────────────────────────────────",
+    `This session edited ${editedFiles.size} distinct file${editedFiles.size === 1 ? "" : "s"} but called no vault_* tools.`,
+    "",
+    "Edited:",
+    ...sampleFiles.map((f) => `  • ${f}`),
+    more > 0 ? `  … +${more} more` : "",
+    "",
+    "If you learned something non-obvious (a gotcha, a decision, a fix pattern),",
+    "consider vault_create_note so the next session lands on it instead of",
+    "re-deriving. Disable with CLAUDE_VAULT_HOOK_DISABLE=1.",
+    "────────────────────────────────────────────────────────",
+    "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+
+  // SessionEnd/Stop hooks surface stderr to the user. No injection into
+  // Claude's context — this is an end-of-session report for the human.
+  process.stderr.write(message + "\n");
+  process.exit(0);
+}
+
+main();

--- a/hooks/vault-gap-report.mjs
+++ b/hooks/vault-gap-report.mjs
@@ -96,11 +96,13 @@ function collectToolUses(transcriptTail) {
     for (const block of content) {
       if (block?.type !== "tool_use") continue;
       const name = String(block.name || "");
-      if (name.includes("__vault_") || name.startsWith("vault_")) {
+      // Strip mcp__<server>__ prefix so vault and edit detection share one path.
+      const bare = name.includes("__") ? name.split("__").pop() : name;
+      if (bare.startsWith("vault_")) {
         vaultUses++;
         continue;
       }
-      const bare = name.includes("__") ? name.split("__").pop() : name;
+      // NotebookEdit uses notebook_path; Edit/Write/MultiEdit use file_path.
       if (EDIT_TOOLS.has(bare)) {
         const fp = block?.input?.file_path || block?.input?.notebook_path;
         if (typeof fp === "string" && fp.length > 0) editedFiles.add(fp);


### PR DESCRIPTION
## Summary
- New SessionEnd/Stop hook `hooks/vault-gap-report.mjs` that reports a gap when the session edited files but never queried the vault
- Stderr-only (no model context injection); never blocks; fail-open on every error path
- Shared utilities with the subagent hook: bounded transcript tail read, path-traversal guard, role-check on tool_use collection
- Tunables: `CLAUDE_VAULT_HOOK_DISABLE=1`, `CLAUDE_VAULT_GAP_THRESHOLD=N` (default 3)
- README updated with SessionEnd wiring example

Closes #64.

## Test plan
- [x] Smoke: triggers when edits ≥ threshold and zero vault_*
- [x] Silent when any vault_* present
- [x] Silent below threshold
- [x] Threshold override honored
- [x] File dedup correct (Set)
- [x] Path traversal rejected (non-absolute / non-.jsonl)
- [x] CLAUDE_VAULT_HOOK_DISABLE=1 exits 0
- [x] tool_use blocks inside user (tool_result carrier) messages ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)