### PR TITLE
docs(vault): document enforcement-gap fixes

### DIFF
--- a/test/retrieval/baseline.json
+++ b/test/retrieval/baseline.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-04-19T22:57:24.334Z",
+  "generatedAt": "2026-04-20T22:49:56.015Z",
   "queryCount": 14,
   "summary": {
     "keyword": {
       "overall": {
-        "recallAt5": 0.3333,
-        "mrrAt5": 0.3333,
+        "recallAt5": 0.9167,
+        "mrrAt5": 0.725,
         "count": 12
       },
       "byCategory": {
@@ -15,23 +15,23 @@
           "count": 4
         },
         "semantic-only": {
-          "recallAt5": 0,
-          "mrrAt5": 0,
+          "recallAt5": 0.6667,
+          "mrrAt5": 0.5,
           "count": 3
         },
         "vocabulary-gap": {
-          "recallAt5": 0,
-          "mrrAt5": 0,
+          "recallAt5": 1,
+          "mrrAt5": 0.35,
           "count": 2
         },
         "graph-context": {
-          "recallAt5": 0,
-          "mrrAt5": 0,
+          "recallAt5": 1,
+          "mrrAt5": 0.5,
           "count": 1
         },
         "multi-section": {
-          "recallAt5": 0,
-          "mrrAt5": 0,
+          "recallAt5": 1,
+          "mrrAt5": 1,
           "count": 2
         },
         "filter-scope": {
@@ -44,13 +44,13 @@
     "semantic": {
       "overall": {
         "recallAt5": 0.6429,
-        "mrrAt5": 0.5595,
+        "mrrAt5": 0.4964,
         "count": 14
       },
       "byCategory": {
         "keyword-only": {
           "recallAt5": 1,
-          "mrrAt5": 0.875,
+          "mrrAt5": 0.675,
           "count": 4
         },
         "semantic-only": {
@@ -75,21 +75,21 @@
         },
         "filter-scope": {
           "recallAt5": 0.5,
-          "mrrAt5": 0.1667,
+          "mrrAt5": 0.125,
           "count": 2
         }
       }
     },
     "chunks": {
       "overall": {
-        "recallAt5": 0.6429,
-        "mrrAt5": 0.5595,
+        "recallAt5": 0.5714,
+        "mrrAt5": 0.4786,
         "count": 14
       },
       "byCategory": {
         "keyword-only": {
-          "recallAt5": 1,
-          "mrrAt5": 0.875,
+          "recallAt5": 0.75,
+          "mrrAt5": 0.625,
           "count": 4
         },
         "semantic-only": {
@@ -114,7 +114,7 @@
         },
         "filter-scope": {
           "recallAt5": 0.5,
-          "mrrAt5": 0.1667,
+          "mrrAt5": 0.1,
           "count": 2
         }
       }

--- a/vault/claude-code-vault/VAULT_SUMMARY.md
+++ b/vault/claude-code-vault/VAULT_SUMMARY.md
@@ -21,6 +21,9 @@ This vault doubles as documentation for `claude-code-vault` itself and as the re
 - Cutting a release? → [[claude-code-vault/runbooks/publish-release]]
 - Confused by a term? → [[claude-code-vault/glossary/core-terms]] or [[shared/glossary/rag-terms]] for cross-project RAG vocabulary
 - Curious *why* the stack looks the way it does? → [[claude-code-vault/adrs/adr-001-local-first-embeddings]]
+- Why MCP descriptions read like routing contracts? → [[claude-code-vault/adrs/adr-006-llm-routing-via-tool-descriptions]]
+- How the orchestrator is pushed vault-first? → [[claude-code-vault/adrs/adr-007-hook-based-vault-enforcement]] + [[claude-code-vault/features/enforcement-hooks]]
+- Spawning a subagent? Read first → [[claude-code-vault/gotchas/subagent-context-isolation]]
 - Looking ahead? → [[claude-code-vault/research/roadmap]]
 
 ## Folders

--- a/vault/claude-code-vault/adrs/adr-006-llm-routing-via-tool-descriptions.md
+++ b/vault/claude-code-vault/adrs/adr-006-llm-routing-via-tool-descriptions.md
@@ -1,0 +1,45 @@
+---
+id: adr-006-llm-routing-via-tool-descriptions
+title: ADR-006 — MCP tool descriptions are LLM routing contracts
+description: Why vault_* descriptions lead with "REACH FOR THIS BEFORE Grep/Read/Glob/subagent" framing and stay under the 1024-char MCP client truncation threshold
+summary: Decision (accepted 2026-04-20) to treat MCP tool descriptions as routing contracts that explicitly redirect the orchestrator from Grep/Read/Glob/subagent to the vault. Each description leads with the "use this instead of X" framing, stays under ~1024 chars to survive client truncation, and drops cross-tool tails and duplicate sentences that bloat the payload without helping routing.
+type: adr
+status: current
+date: 2026-04-20
+lastVerified: 2026-04-20
+tags: [decision, mcp, llm-ergonomics]
+---
+
+# ADR-006 — MCP tool descriptions are LLM routing contracts
+
+## Context
+
+The vault is only useful if Claude Code reaches for it before `Grep`, `Read`, `Glob`, or spawning a subagent. In practice, well-named tools with accurate but neutral descriptions ("search the vault by keyword") lost the routing fight: Grep was faster to think of, and the model had no signal that the vault was the *preferred* path.
+
+The gap is a routing problem, not a capability problem. Descriptions are the only channel the orchestrator reliably reads before tool selection — CLAUDE.md is not loaded into subagents, and hooks only fire on specific events.
+
+MCP clients also truncate tool descriptions around ~1024 characters. Descriptions that ran past that threshold lost their tail silently, which is exactly where prior versions had stashed the "prefer this over Grep" hint.
+
+## Decision
+
+Every `vault_*` tool description must:
+
+1. **Lead with a routing directive** — "REACH FOR THIS BEFORE Grep/Read/Glob/subagent" (or the narrower equivalent for chunk/related tools), not a neutral capability statement.
+2. **Stay under 1024 characters** so the routing hint survives client truncation. Measured on publish; median is ~720 chars, max ~960.
+3. **Drop cross-tool tails** ("see also vault_related…") that duplicate information the orchestrator will discover from the sibling tool's own description.
+4. **Keep one concrete example** of the query shape the tool is best at. Remove rationale, motivation, and "why this exists" prose — the orchestrator does not need to justify calling a tool, only know when to call it.
+
+See the post-trim payloads in [lib/mcp.js](../../../lib/mcp.js).
+
+## Consequences
+
+- **Good:** the orchestrator routes vault-first on question-shaped intent without hooks firing. Descriptions stay legible to a human reading the MCP tool list.
+- **Good:** bounded budget means new tools can't silently push existing routing hints past the truncation cliff.
+- **Watch:** future tool additions must re-measure total surface — 13 tools × ~800 chars is already ~10 KB, which pressures clients that paginate the tool list.
+- **Accepted cost:** rationale that used to live in descriptions now lives here and in [[claude-code-vault/features/enforcement-hooks]]. The tool list is smaller and more ruthless.
+
+## Related
+
+- [[claude-code-vault/adrs/adr-007-hook-based-vault-enforcement]] — the escalation layer for cases where descriptions alone are insufficient
+- [[claude-code-vault/features/enforcement-hooks]] — the three hooks that enforce the routing contract at runtime
+- [[claude-code-vault/gotchas/subagent-context-isolation]] — why descriptions matter more than CLAUDE.md for subagents

--- a/vault/claude-code-vault/adrs/adr-007-hook-based-vault-enforcement.md
+++ b/vault/claude-code-vault/adrs/adr-007-hook-based-vault-enforcement.md
@@ -1,0 +1,65 @@
+---
+id: adr-007-hook-based-vault-enforcement
+title: ADR-007 — hook-based vault enforcement (nudge → gate → report)
+description: Why three Claude Code hooks escalate from nudge to block to post-session report, and why they ship as opt-in rather than auto-install
+summary: Decision (accepted 2026-04-20) to close the "orchestrator forgets the vault" gap with three escalating hooks — a once-per-session Grep/Glob nudge, an Agent-spawn gate that blocks cold subagents, and a SessionEnd gap report. All ship opt-in under `hooks/` in the npm tarball and share a fail-open invariant.
+type: adr
+status: current
+date: 2026-04-20
+lastVerified: 2026-04-20
+tags: [decision, hooks, enforcement]
+---
+
+# ADR-007 — hook-based vault enforcement
+
+## Context
+
+Tool descriptions (see [[claude-code-vault/adrs/adr-006-llm-routing-via-tool-descriptions]]) handle the happy path but not three failure modes observed in real sessions:
+
+1. **Filesystem reflex.** The orchestrator reaches for `Grep`/`Glob` on a question-shaped prompt before considering the vault.
+2. **Cold subagents.** Spawned agents do not inherit CLAUDE.md and start without any vault context, re-deriving patterns that are already documented. See [[claude-code-vault/gotchas/subagent-context-isolation]].
+3. **Write-loop asymmetry.** Sessions that learn something non-obvious still end without a `vault_create_note`, so the next session re-derives it.
+
+Descriptions cannot solve any of these — they load too late (after tool selection) or not at all (subagents).
+
+## Decision
+
+Three hooks, escalating in firmness, each shipped opt-in:
+
+| Hook | Event | Strength | Purpose |
+| --- | --- | --- | --- |
+| `vault-first-reminder.mjs` | `PreToolUse` on `Grep`/`Glob` | **Nudge** (additionalContext) | Once-per-session reminder suggesting `vault_semantic_search` with the pattern pre-formulated |
+| `vault-first-subagent.mjs` | `PreToolUse` on `Agent`/`Task` | **Gate** (permissionDecision: deny) | Blocks subagent spawn if no `vault_*` call appears in the last 20 tool uses |
+| `vault-gap-report.mjs` | `SessionEnd` or `Stop` | **Report** (stderr) | Prints a gap notice if ≥3 distinct files were edited with zero `vault_*` calls |
+
+Shared invariants every hook must honor:
+
+- **Fail-open.** Any error path exits 0 (allow). Malformed stdin, missing transcript, parse failure, read error — none block the user.
+- **Bounded transcript read.** `openSync` + `readSync` at a tail offset. Never `readFileSync` of the whole JSONL.
+- **Path-traversal guard.** `transcript_path` must be absolute and end in `.jsonl` before we open it.
+- **Role check.** Only count `tool_use` blocks in `assistant` messages; user messages carry `tool_result` replies that can embed tool_use references which must not be counted as fresh invocations.
+- **No context injection.** The gap report writes to stderr only — it is feedback for the human, not a self-referential instruction to the model. Only the subagent gate injects text, and it does so via the documented `permissionDecisionReason` field.
+- **Single escape hatch.** `CLAUDE_VAULT_HOOK_DISABLE=1` silences all three.
+
+## Why opt-in
+
+Hooks require consumer action (`.claude/settings.json` wiring) rather than auto-activating. Reasons:
+
+- Auto-installing hooks on `npm install` is hostile — hooks run arbitrary code on every tool use.
+- Projects differ on tolerance for a hard gate (the subagent hook denies spawns). Opt-in lets consumers pick nudge-only, gate-only, or all three.
+- Wiring lives in the consumer's repo and shows up in diffs, so enforcement is auditable.
+
+See [[claude-code-vault/features/enforcement-hooks]] for wiring and tunables.
+
+## Consequences
+
+- **Good:** the three failure modes above now have a durable, testable answer. Every hook has a smoke test matrix covering disabled / silent / triggered branches.
+- **Good:** adding a fourth hook later (e.g. a Write-time "did you vault this?" nudge) slots into the same shape — shared utilities, same invariants.
+- **Watch:** the subagent gate is the only *blocking* hook. If a consumer finds it too strict, the escape valve is `CLAUDE_VAULT_HOOK_DISABLE=1` — not softening the hook, which would reopen the cold-subagent hole.
+- **Accepted cost:** three separate files with some duplicated parsing. Extracting a shared `lib/hook-utils.mjs` is tempting but would break the "each hook is a single-file copy-pasteable unit" property that makes them easy to audit.
+
+## Related
+
+- [[claude-code-vault/adrs/adr-006-llm-routing-via-tool-descriptions]] — the lighter-weight routing layer these hooks backstop
+- [[claude-code-vault/features/enforcement-hooks]] — consumer-facing wiring and tunables
+- [[claude-code-vault/gotchas/subagent-context-isolation]] — the specific problem the subagent gate solves

--- a/vault/claude-code-vault/features/enforcement-hooks.md
+++ b/vault/claude-code-vault/features/enforcement-hooks.md
@@ -1,0 +1,103 @@
+---
+id: enforcement-hooks
+title: Enforcement hooks — wiring and tunables
+description: Three opt-in Claude Code hooks that enforce vault-first behavior — the Grep/Glob nudge, the Agent spawn gate, and the SessionEnd gap report
+summary: Ship from `hooks/` in the npm tarball. Consumers wire them into `.claude/settings.json`. All share `CLAUDE_VAULT_HOOK_DISABLE=1` as the escape hatch and fail-open on every error path. Each hook is a single self-contained .mjs file with no runtime dependencies beyond Node 20 stdlib.
+type: feature
+status: current
+lastVerified: 2026-04-20
+tags: [hooks, enforcement, configuration]
+---
+
+# Enforcement hooks
+
+Three hooks that backstop the [[claude-code-vault/adrs/adr-006-llm-routing-via-tool-descriptions|MCP description routing]] when the orchestrator forgets the vault exists.
+
+## 1. `vault-first-reminder.mjs` — Grep/Glob nudge
+
+Fires once per session on the first `Grep` or `Glob`. Emits `additionalContext` suggesting `vault_semantic_search` with the pattern pre-formulated. Never blocks.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep|Glob",
+        "hooks": [{
+          "type": "command",
+          "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-first-reminder.mjs"
+        }]
+      }
+    ]
+  }
+}
+```
+
+State lives in `<os.tmpdir()>/claude-code-vault-hook-state/<sanitized-session-id>.seen`. Exclusive create (`wx`) guards against races.
+
+## 2. `vault-first-subagent.mjs` — Agent spawn gate
+
+Fires on `PreToolUse` for `Agent`/`Task`. Scans the transcript tail for recent `vault_*` calls. If none in the last 20 tool uses, returns `permissionDecision: "deny"` with a reason telling the orchestrator to query the vault first.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent|Task",
+        "hooks": [{
+          "type": "command",
+          "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-first-subagent.mjs"
+        }]
+      }
+    ]
+  }
+}
+```
+
+This is the only *blocking* hook. Rationale in [[claude-code-vault/adrs/adr-007-hook-based-vault-enforcement]] and [[claude-code-vault/gotchas/subagent-context-isolation]].
+
+## 3. `vault-gap-report.mjs` — SessionEnd gap report
+
+Fires on `SessionEnd` (or `Stop` for per-turn reports). Collects distinct file paths written by `Edit`/`Write`/`NotebookEdit`/`MultiEdit` and counts `vault_*` calls. If edits ≥ threshold (default 3) and vault calls == 0, prints a reminder to stderr. Stderr is visible to the user but NOT injected into Claude's context.
+
+```json
+{
+  "hooks": {
+    "SessionEnd": [{
+      "hooks": [{
+        "type": "command",
+        "command": "node ${CLAUDE_PROJECT_DIR}/node_modules/claude-code-vault/hooks/vault-gap-report.mjs"
+      }]
+    }]
+  }
+}
+```
+
+## Tunables (shared)
+
+| Env var | Effect | Default |
+| --- | --- | --- |
+| `CLAUDE_VAULT_HOOK_DISABLE=1` | Silences all three hooks for the current shell | unset |
+| `CLAUDE_VAULT_SUBAGENT_LOOKBACK=N` | How many recent tool uses the subagent gate scans | 20 |
+| `CLAUDE_VAULT_GAP_THRESHOLD=N` | Minimum distinct edited files to trigger the gap report | 3 |
+
+## Invariants
+
+Every hook must:
+
+- Exit 0 on any error path (fail-open). Never brick the user's workflow.
+- Read the transcript with a bounded `openSync` + `readSync` tail (256 KB for the subagent gate, 1 MB for the gap report). Never `readFileSync` the whole JSONL.
+- Guard `transcript_path` with an absolute-path + `.jsonl`-suffix check before opening.
+- Only count `tool_use` blocks from `assistant` messages. User messages carry `tool_result` replies which embed tool_use references that must not be counted as fresh invocations.
+- Sanitize any user-controlled string (session id, query pattern) before echoing it into hook output — strip control chars and backticks to prevent prompt injection.
+
+## Testing
+
+Each hook has an adversarial smoke-test matrix covering: disabled env var, missing stdin, malformed JSON, path traversal, non-`.jsonl` transcript, zero-tool transcript, vault-present transcript, and user-message tool_use-embedded transcripts. See commit history under `feat/hook-*` branches for the exact cases.
+
+## Related
+
+- [[claude-code-vault/adrs/adr-006-llm-routing-via-tool-descriptions]]
+- [[claude-code-vault/adrs/adr-007-hook-based-vault-enforcement]]
+- [[claude-code-vault/gotchas/subagent-context-isolation]]

--- a/vault/claude-code-vault/gotchas/subagent-context-isolation.md
+++ b/vault/claude-code-vault/gotchas/subagent-context-isolation.md
@@ -1,0 +1,52 @@
+---
+id: subagent-context-isolation
+title: Subagents do NOT inherit CLAUDE.md
+description: Why spawning an Agent/Task cold wastes tokens re-deriving documented patterns, and how claude-code-vault closes the gap
+summary: Claude Code subagents spawn with a fresh context and do not receive the parent's CLAUDE.md, memory, or prior tool results. Patterns documented in the parent's vault or instructions are invisible to the subagent unless explicitly passed in the prompt. This is the motivation for the Agent-spawn gate hook.
+type: gotcha
+status: current
+lastVerified: 2026-04-20
+tags: [subagents, context, hooks]
+---
+
+# Subagents do NOT inherit CLAUDE.md
+
+## Symptom
+
+A subagent spawned via `Agent`/`Task` produces work that contradicts project conventions documented in CLAUDE.md or the vault. It re-derives patterns ("let me first understand the project structure…") that the parent session already has in context. Token usage balloons because the subagent repeats exploration work the parent already did.
+
+## Cause
+
+Subagents start with a **cold context**. They receive:
+
+- The prompt the orchestrator passes in the `Agent` call
+- The system prompt for their assigned agent type (if any)
+- Access to the tools their agent type declares
+
+They do NOT receive:
+
+- The parent's CLAUDE.md
+- The parent's prior tool results
+- The parent's memory files
+- Any MCP tool descriptions beyond what their agent type explicitly enables
+
+If your vault-first behavior depends on CLAUDE.md routing rules, those rules evaporate the moment you spawn a subagent. The subagent will default to `Grep`/`Glob`/`Read` because nothing in its context says otherwise.
+
+## Fix
+
+Two layers, both necessary:
+
+1. **Write the relevant vault hits into the subagent's prompt.** Do a `vault_semantic_search` on the task statement *before* spawning, and pass the top 2–3 hits inline in the Agent prompt. The subagent will use them as ground truth.
+2. **Install the subagent gate hook** ([[claude-code-vault/features/enforcement-hooks]]). It blocks spawns when no `vault_*` call appears in the last 20 tool uses, forcing the orchestrator to query the vault first.
+
+Neither alone is sufficient: without (1), the subagent has no vault context even after the hook passes. Without (2), it's easy to forget.
+
+## Non-fix
+
+Do NOT try to "inject CLAUDE.md into the subagent" by pasting it into the prompt. That defeats the purpose of subagents (fresh context, small surface area) and still doesn't help if the relevant knowledge is in the vault rather than CLAUDE.md. The right primitive is targeted vault search → pass hits into the prompt.
+
+## Related
+
+- [[claude-code-vault/adrs/adr-007-hook-based-vault-enforcement]] — the hook that enforces this at runtime
+- [[claude-code-vault/features/enforcement-hooks]] — wiring and tunables
+- [[claude-code-vault/adrs/adr-006-llm-routing-via-tool-descriptions]] — why the parent-side routing depends on MCP descriptions, which *are* visible to subagents


### PR DESCRIPTION
## Summary
- Four new self-doc notes capturing the rationale behind the enforcement-gap PRs (#65 descriptions, #66 nudge, #67 gate, #68 gap report)
- Two ADRs (006, 007), one feature note (enforcement-hooks), one gotcha (subagent-context-isolation)
- VAULT_SUMMARY updated to link the new notes

All notes target the public vault at \`vault/claude-code-vault/\` and follow the existing frontmatter + wiki-link conventions.

## Test plan
- [ ] Render: open each note, verify frontmatter parses and wiki-links resolve
- [ ] Retrieval eval: \`npm run eval\` — no regression (new notes broaden coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)