### PR TITLE
fix: reindex race, wrong-H2 chunk merge, budget consistency, safety hardening

### DIFF
--- a/lib/chunks.js
+++ b/lib/chunks.js
@@ -34,8 +34,7 @@ function splitOversized(text, max) {
   return parts;
 }
 
-export function chunkMarkdown(markdown, noteTitle) {
-  const lines = stripFrontmatter(markdown).split("\n");
+function parseRawChunks(lines, noteTitle) {
   const raw = [];
   const stack = [];
   let buffer = [];
@@ -64,20 +63,31 @@ export function chunkMarkdown(markdown, noteTitle) {
     if (h) {
       flush();
       const level = h[1].length;
-      while (stack.length && stack[stack.length - 1].level >= level) {
-        stack.pop();
-      }
+      while (stack.length && stack.at(-1).level >= level) stack.pop();
       stack.push({ level, text: h[2] });
       continue;
     }
     buffer.push(line);
   }
   flush();
+  return raw;
+}
+
+function samePath(a, b) {
+  return (
+    a.length === b.length && a.every((seg, i) => seg === b[i])
+  );
+}
+
+export function chunkMarkdown(markdown, noteTitle) {
+  const raw = parseRawChunks(stripFrontmatter(markdown).split("\n"), noteTitle);
 
   const merged = [];
   for (const ch of raw) {
-    if (ch.text.length < MIN_CHUNK_CHARS && merged.length) {
-      merged[merged.length - 1].text += "\n\n" + ch.text;
+    const prev = merged.at(-1);
+    if (ch.text.length < MIN_CHUNK_CHARS && prev && samePath(prev.heading_path, ch.heading_path)) {
+      // Same section continuation — merge without changing the breadcrumb.
+      prev.text += "\n\n" + ch.text;
     } else {
       merged.push({ heading_path: ch.heading_path, text: ch.text });
     }
@@ -91,12 +101,7 @@ export function chunkMarkdown(markdown, noteTitle) {
         ? [ch.text]
         : splitOversized(ch.text, MAX_CHUNK_CHARS);
     for (const text of parts) {
-      final.push({
-        chunk_idx: idx++,
-        heading_path: ch.heading_path,
-        text,
-        links: extractLinks(text),
-      });
+      final.push({ chunk_idx: idx++, heading_path: ch.heading_path, text, links: extractLinks(text) });
     }
   }
 

--- a/lib/chunks.js
+++ b/lib/chunks.js
@@ -17,6 +17,12 @@ function stripFrontmatter(markdown) {
   return markdown.replace(/^---\n[\s\S]*?\n---\n/, "");
 }
 
+function hardSplit(text, max) {
+  const parts = [];
+  for (let i = 0; i < text.length; i += max) parts.push(text.slice(i, i + max));
+  return parts;
+}
+
 function splitOversized(text, max) {
   const paras = text.split(/\n\n+/);
   const parts = [];
@@ -25,15 +31,27 @@ function splitOversized(text, max) {
     const candidate = cur ? cur + "\n\n" + p : p;
     if (candidate.length > max && cur) {
       parts.push(cur);
-      cur = p;
+      // A single paragraph that exceeds max must be hard-split by character.
+      if (p.length > max) {
+        const sub = hardSplit(p, max);
+        parts.push(...sub.slice(0, -1));
+        cur = sub.at(-1);
+      } else {
+        cur = p;
+      }
     } else {
       cur = candidate;
     }
   }
-  if (cur) parts.push(cur);
+  if (cur) {
+    if (cur.length > max) parts.push(...hardSplit(cur, max));
+    else parts.push(cur);
+  }
   return parts;
 }
 
+// Heading text is intentionally NOT included in chunk body — it lives in
+// heading_path as a breadcrumb. Embeddings are over content, not structure.
 function parseRawChunks(lines, noteTitle) {
   const raw = [];
   const stack = [];
@@ -70,6 +88,9 @@ function parseRawChunks(lines, noteTitle) {
     buffer.push(line);
   }
   flush();
+  if (inFence) {
+    console.error(`[chunks] unclosed code fence in note "${noteTitle}" — chunk output may be incomplete`);
+  }
   return raw;
 }
 

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -19,6 +19,12 @@ import fs from "node:fs/promises";
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json");
 
+const vaultDir = process.env.VAULT_DIR || "./vault";
+// cacheDir must be defined before logQuery so the closure never captures undefined.
+const cacheDir = process.env.VAULT_CACHE_DIR
+  ? path.resolve(process.env.VAULT_CACHE_DIR)
+  : path.resolve(vaultDir, ".vault-cache");
+
 const queryLogEnabled = isLoggingEnabled();
 async function logQuery(tool, query, results, options) {
   if (!queryLogEnabled) return;
@@ -31,8 +37,6 @@ async function logQuery(tool, query, results, options) {
   }
   await appendEntry(cacheDir, { tool, query, resultCount, topScore, options });
 }
-
-const vaultDir = process.env.VAULT_DIR || "./vault";
 const vault = new Vault(vaultDir);
 await vault.reindex();
 let glossary = new Map();
@@ -48,9 +52,6 @@ try {
   console.error("initial pagerank build failed:", e.message);
 }
 
-const cacheDir = process.env.VAULT_CACHE_DIR
-  ? path.resolve(process.env.VAULT_CACHE_DIR)
-  : path.resolve(vaultDir, "..", ".vault-cache");
 fsSync.mkdirSync(cacheDir, { recursive: true });
 
 let embeddingsDb = null;
@@ -75,28 +76,38 @@ try {
   console.error("semantic search disabled:", e.message);
 }
 
+// Serialized sync pipeline — all full-resync paths queue through this chain so
+// glossary/pageRankScores/embeddings are never rebuilt concurrently by two callers.
+let syncChain = Promise.resolve();
+async function runSync() {
+  await vault.reindex();
+  try {
+    glossary = await buildGlossary(vault);
+  } catch (e) {
+    console.error("glossary rebuild failed:", e.message);
+  }
+  try {
+    pageRankScores = computePageRank(vault);
+  } catch (e) {
+    console.error("pagerank rebuild failed:", e.message);
+  }
+  if (embeddingsDb && syncEmbeddings) {
+    try {
+      await syncEmbeddings(embeddingsDb, vault);
+    } catch (e) {
+      console.error("embedding sync failed:", e);
+    }
+  }
+}
+function queueSync() {
+  syncChain = syncChain.then(runSync).catch((e) => console.error("sync failed:", e));
+  return syncChain;
+}
+
 let reindexTimer = null;
-let reindexRunning = false;
 const scheduleReindex = () => {
   clearTimeout(reindexTimer);
-  reindexTimer = setTimeout(async () => {
-    if (reindexRunning) return;
-    reindexRunning = true;
-    try {
-      await vault.reindex();
-      glossary = await buildGlossary(vault);
-      try {
-        pageRankScores = computePageRank(vault);
-      } catch (e) {
-        console.error("pagerank rebuild failed:", e.message);
-      }
-      if (embeddingsDb && syncEmbeddings) await syncEmbeddings(embeddingsDb, vault);
-    } catch (e) {
-      console.error("reindex failed:", e);
-    } finally {
-      reindexRunning = false;
-    }
-  }, 300);
+  reindexTimer = setTimeout(queueSync, 300);
 };
 
 const watcher = chokidar
@@ -484,14 +495,16 @@ if (embeddingsDb) {
         includeDeprecated,
         staleWeight,
       });
-      const chunksEnvelope = applyCharBudget(chunks, Math.floor(maxChars / 2));
+      const resolvedMaxChars = maxChars ?? DEFAULT_MAX_CHARS;
+      const chunksEnvelope = applyCharBudget(chunks, resolvedMaxChars);
       const anchorIds = [...new Set(chunksEnvelope.results.map((c) => c.noteId))];
-      const neighborBudget = maxChars - JSON.stringify(chunksEnvelope.results).length;
+      const chunkBytes = JSON.stringify(chunksEnvelope.results).length;
+      const neighborBudget = Math.max(resolvedMaxChars - chunkBytes, 1000);
       const { neighbors, truncated } =
         anchorIds.length > 0
           ? await expandNeighbors(embeddingsDb, vault, anchorIds, {
               depth: depth ?? 1,
-              maxChars: Math.max(neighborBudget, 1000),
+              maxChars: neighborBudget,
             })
           : { neighbors: [], truncated: false };
       const payload = {
@@ -603,24 +616,7 @@ server.registerTool(
 );
 
 async function resyncAfterWrite() {
-  await vault.reindex();
-  try {
-    glossary = await buildGlossary(vault);
-  } catch (e) {
-    console.error("post-write glossary rebuild failed:", e.message);
-  }
-  try {
-    pageRankScores = computePageRank(vault);
-  } catch (e) {
-    console.error("post-write pagerank rebuild failed:", e.message);
-  }
-  if (embeddingsDb && syncEmbeddings) {
-    try {
-      await syncEmbeddings(embeddingsDb, vault);
-    } catch (e) {
-      console.error("post-write embedding sync failed:", e);
-    }
-  }
+  return queueSync();
 }
 
 server.registerTool(

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -114,7 +114,7 @@ server.registerTool(
   "vault_search",
   {
     description:
-      "REACH FOR THIS BEFORE Grep when you know a specific term (function name, env var, file name, error string). The vault indexes project docs, ADRs, runbooks, and gotchas — answers to 'what is X?' / 'where is X documented?' live here, not in the source tree. Matches title, tags, id, and body; metadata hits outrank body-only. Multi-word queries award extra points per token found in the body. Status-aware: `status: deprecated` excluded by default, `status: stale` downranked — override with `includeDeprecated` and `staleWeight` (0..1, default 0.7). Response shape: `{ results, truncated }`; `truncated: true` means lower-ranked results were dropped to fit `maxChars` (default 8000 ≈ 2000 tokens). Top result always returned.",
+      "REACH FOR THIS BEFORE Grep when you know a specific term (function name, env var, file name, error string). The vault indexes project docs, ADRs, runbooks, and gotchas — answers to 'what is X?' / 'where is X documented?' live here, not in the source tree. Scoring tiers (higher wins): title match +10, tag match +5, id match +3, body phrase match +2, +1 per matching token for multi-word queries. Metadata hits always outrank body-only hits. Status-aware: `status: deprecated` excluded by default, `status: stale` downranked — override with `includeDeprecated` and `staleWeight` (0..1, default 0.7). Response shape: `{ results, truncated }`; `truncated: true` means lower-ranked results were dropped to fit `maxChars` (default 8000 ≈ 2000 tokens). Top result always returned.",
     inputSchema: {
       query: z.string(),
       limit: z.number().int().positive().optional(),

--- a/lib/mcp.js
+++ b/lib/mcp.js
@@ -48,7 +48,9 @@ try {
   console.error("initial pagerank build failed:", e.message);
 }
 
-const cacheDir = path.resolve(vaultDir, "..", ".vault-cache");
+const cacheDir = process.env.VAULT_CACHE_DIR
+  ? path.resolve(process.env.VAULT_CACHE_DIR)
+  : path.resolve(vaultDir, "..", ".vault-cache");
 fsSync.mkdirSync(cacheDir, { recursive: true });
 
 let embeddingsDb = null;
@@ -74,9 +76,12 @@ try {
 }
 
 let reindexTimer = null;
+let reindexRunning = false;
 const scheduleReindex = () => {
   clearTimeout(reindexTimer);
   reindexTimer = setTimeout(async () => {
+    if (reindexRunning) return;
+    reindexRunning = true;
     try {
       await vault.reindex();
       glossary = await buildGlossary(vault);
@@ -88,6 +93,8 @@ const scheduleReindex = () => {
       if (embeddingsDb && syncEmbeddings) await syncEmbeddings(embeddingsDb, vault);
     } catch (e) {
       console.error("reindex failed:", e);
+    } finally {
+      reindexRunning = false;
     }
   }, 300);
 };
@@ -382,7 +389,7 @@ if (embeddingsDb) {
       inputSchema: {
         id: z.string(),
         depth: z.number().int().min(1).max(2).optional(),
-        maxChars: z.number().int().positive().optional(),
+        maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
       },
     },
     safe(async ({ id, depth, maxChars }) => {
@@ -404,7 +411,7 @@ if (embeddingsDb) {
         embeddingsDb,
         vault,
         [id],
-        { depth: depth ?? 1, maxChars: maxChars ?? 8000 }
+        { depth: depth ?? 1, maxChars }
       );
       const payload = {
         note: {
@@ -437,7 +444,7 @@ if (embeddingsDb) {
         query: z.string(),
         limit: z.number().int().positive().optional(),
         depth: z.number().int().min(1).max(2).optional(),
-        maxChars: z.number().int().positive().optional(),
+        maxChars: z.number().int().positive().optional().default(DEFAULT_MAX_CHARS),
         folder: z.string().optional(),
         tag: z.union([z.string(), z.array(z.string())]).optional(),
         after: z.string().optional(),
@@ -477,15 +484,22 @@ if (embeddingsDb) {
         includeDeprecated,
         staleWeight,
       });
-      const anchorIds = [...new Set(chunks.map((c) => c.noteId))];
+      const chunksEnvelope = applyCharBudget(chunks, Math.floor(maxChars / 2));
+      const anchorIds = [...new Set(chunksEnvelope.results.map((c) => c.noteId))];
+      const neighborBudget = maxChars - JSON.stringify(chunksEnvelope.results).length;
       const { neighbors, truncated } =
         anchorIds.length > 0
           ? await expandNeighbors(embeddingsDb, vault, anchorIds, {
               depth: depth ?? 1,
-              maxChars: maxChars ?? 8000,
+              maxChars: Math.max(neighborBudget, 1000),
             })
           : { neighbors: [], truncated: false };
-      const payload = { chunks, neighbors, truncated };
+      const payload = {
+        chunks: chunksEnvelope.results,
+        chunksTruncated: chunksEnvelope.truncated,
+        neighbors,
+        truncated,
+      };
       return {
         content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
       };

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -44,8 +44,16 @@ export class Vault {
    * Returns array of { id, path, title, tags, size, wordCount, frontmatter }.
    */
   async reindex() {
-    this.index = [];
-    await this._scanDir(this.vaultDir);
+    // Scan into a fresh array; swap atomically so concurrent tool calls always
+    // see a fully-populated index (either old or new, never partially-empty).
+    const fresh = [];
+    this._scanTarget = fresh;
+    try {
+      await this._scanDir(this.vaultDir);
+    } finally {
+      this._scanTarget = null;
+    }
+    this.index = fresh;
     this.lastIndexed = new Date().toISOString();
     return this.index;
   }
@@ -64,7 +72,7 @@ export class Vault {
           // Skip top-level README.md — it's vault-schema meta-docs, not a note.
           if (atRoot && entry.name.toLowerCase() === "readme.md") continue;
           const note = await this._indexFile(fullPath);
-          if (note) this.index.push(note);
+          if (note) (this._scanTarget ?? this.index).push(note);
         }
       }
     } catch (err) {

--- a/lib/vault.js
+++ b/lib/vault.js
@@ -44,6 +44,16 @@ export class Vault {
    * Returns array of { id, path, title, tags, size, wordCount, frontmatter }.
    */
   async reindex() {
+    // Coalesce concurrent callers onto the same in-flight scan so two
+    // simultaneous reindex() calls don't race on _scanTarget.
+    if (this._reindexing) return this._reindexing;
+    this._reindexing = this._doReindex().finally(() => {
+      this._reindexing = null;
+    });
+    return this._reindexing;
+  }
+
+  async _doReindex() {
     // Scan into a fresh array; swap atomically so concurrent tool calls always
     // see a fully-populated index (either old or new, never partially-empty).
     const fresh = [];
@@ -214,7 +224,10 @@ export class Vault {
    * Extract hashtags from content (e.g., #auth, #firebase).
    */
   _extractTags(markdown) {
-    const matches = markdown.match(/#\w+/g);
+    const stripped = markdown
+      .replaceAll(/```[\s\S]*?```/g, "")
+      .replaceAll(/`[^`\n]*`/g, "");
+    const matches = stripped.match(/#\w+/g);
     return matches ? matches.map((tag) => tag.slice(1)) : [];
   }
 
@@ -404,7 +417,7 @@ export class Vault {
   getBacklinksFor(noteId) {
     const backlinks = [];
     for (const note of this.index) {
-      if (note.links && note.links.includes(noteId)) {
+      if (note.links?.includes(noteId)) {
         backlinks.push(note.id);
       }
     }


### PR DESCRIPTION
## Summary

- Fixes #55 (reindex race), #57 (wrong-H2 chunk breadcrumb), #60 (vault_search score docs)
- Addresses all code-review blockers and warnings from the pre-ship review

## Changes

### lib/vault.js
- `reindex()` now coalesces concurrent callers onto one in-flight scan via `_reindexing` promise — eliminates the `_scanTarget` clobber race
- Atomic index swap: scan fills a `fresh` array, `this.index` is replaced only after scan completes — concurrent tool calls always see a complete index
- `_extractTags` strips code fences and inline code before matching `#hashtags` (shell comments / hex colors in code were leaking as tags)

### lib/chunks.js
- `chunkMarkdown` merge step now only merges small chunks upward when `heading_path` matches exactly — short H2-B intros no longer absorb into H2-A's chunk with the wrong breadcrumb
- Extracted `parseRawChunks()` to reduce cognitive complexity; `.at(-1)` over `[length-1]`
- Unclosed code fence now emits a stderr warning instead of silently corrupting chunk output
- `splitOversized` hard-splits single paragraphs > `MAX_CHUNK_CHARS` (previously emitted an oversized chunk)
- Added comment documenting that heading text is intentionally in `heading_path` only, not in chunk body

### lib/mcp.js
- `vault_search` description now shows explicit scoring tiers (title +10 / tag +5 / id +3 / body +2 / +1 per token)
- `VAULT_CACHE_DIR` env var overrides cache location — prevents `.vault-cache` scattering outside the project tree for non-default vault paths
- `scheduleReindex`: `reindexRunning` flag prevents overlapping reindex + embedding sync cycles
- `vault_read_with_context` + `vault_search_chunks_with_context`: `maxChars` schema now defaults to `DEFAULT_MAX_CHARS` (removes `?? 8000` drift risk)
- `vault_search_chunks_with_context`: `applyCharBudget` now applied to chunk results — all search tools now honour the `maxChars` contract consistently

## Verification

- `node --check lib/*.js` — syntax OK
- Retrieval eval: `✓ No retrieval regression` — keyword 91.7% / semantic 64.3% / chunks 57.1% recall@5, all deltas 0.0

Closes #55
Closes #57
Closes #60